### PR TITLE
test: add deterministic coverage for cron schedulers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Development
+npm run dev              # Start dev server with nodemon (auto-reload)
+npm run build            # Compile TypeScript to dist/
+npm start                # Start production server (node dist/index.js)
+
+# Type checking & linting
+npm run lint             # tsc --noEmit (type-check only, no output)
+
+# Testing
+npm test                 # Run all tests
+npm run test:watch       # Run tests in watch mode
+
+# Run a single test file
+npx jest src/tests/auth-race.spec.ts
+npx jest --testPathPattern="education-tip"
+
+# Database
+npm run prisma:generate  # Regenerate Prisma client after schema changes
+npm run prisma:migrate   # Run pending migrations
+
+# CI (runs lint → build → test)
+npm run ci
+```
+
+## Architecture
+
+**Layer structure:** Routes → Services → Prisma ORM → PostgreSQL
+
+- [src/index.ts](src/index.ts) — Express app factory and server startup
+- [src/socket.ts](src/socket.ts) — Socket.IO initialization
+- [src/routes/](src/routes/) — Express route handlers (auth, rounds, predictions, leaderboard, chat, notifications, education, price, user)
+- [src/services/](src/services/) — All business logic; routes are thin wrappers over services
+- [src/middleware/](src/middleware/) — Auth (JWT), rate limiting, Zod-based request validation
+- [src/lib/](src/lib/) — Prisma singleton client
+- [src/schemas/](src/schemas/) — Zod validation schemas (shared between middleware and services)
+- [src/utils/](src/utils/) — JWT helpers, challenge generation, decimal math, Winston logger
+- [prisma/schema.prisma](prisma/schema.prisma) — Single source of truth for the database schema
+
+**Core domain concepts:**
+- **Rounds** — Prediction market rounds with `UP_DOWN` or `LEGENDS` game modes; managed by cron scheduler in [src/services/round-scheduler.service.ts](src/services/round-scheduler.service.ts)
+- **Predictions** — User predictions on round outcomes; placement is transactional and race-safe
+- **Resolution** — Rounds are auto-resolved by comparing entry/exit XLM price via CoinGecko oracle ([src/services/oracle.ts](src/services/oracle.ts))
+- **Auth** — Wallet signature challenge/connect flow using Stellar keypairs; challenges are atomically consumed (one-time use)
+- **Soroban** — Smart contract interactions via `@tevalabs/xelma-bindings` and `@stellar/stellar-sdk`; controlled by `SOROBAN_ADMIN_SECRET` / `SOROBAN_ORACLE_SECRET`
+- **WebSocket** — Real-time events (round open/close/resolve, price ticks, notifications) broadcast via Socket.IO in [src/services/websocket.service.ts](src/services/websocket.service.ts)
+
+**Monetary precision:** All balance/amount fields use `Decimal(20, 8)` in Prisma. Never use native JS floats for financial math — use the utilities in [src/utils/decimal.ts](src/utils/decimal.ts).
+
+## Testing
+
+Tests live in `src/tests/*.spec.ts`. Several tests are **excluded from the default test run** in [jest.config.ts](jest.config.ts) (`testPathIgnorePatterns`): `rounds.routes.spec.ts`, `predictions.routes.spec.ts`, `round.spec.ts`, `concurrent-rounds.spec.ts`, `education-tip.route.spec.ts`.
+
+Tests require a running PostgreSQL database. The test environment is configured in [.env.test](.env.test) and loaded by [jest.setup.js](jest.setup.js). The CI pipeline uses a PostgreSQL 16 service container.
+
+## Key Environment Variables
+
+See [.env.example](.env.example) for the full list. Critical variables:
+
+| Variable | Purpose |
+|---|---|
+| `DATABASE_URL` | PostgreSQL connection string |
+| `JWT_SECRET` | Required for server startup |
+| `SOROBAN_CONTRACT_ID` | Deployed prediction market contract |
+| `SOROBAN_ADMIN_SECRET` | Admin keypair for contract operations |
+| `SOROBAN_ORACLE_SECRET` | Oracle keypair for price settlement |
+| `ROUND_SCHEDULER_ENABLED` | Set to `true` to activate cron-based round creation |
+| `ROUND_SCHEDULER_MODE` | `UP_DOWN` or `LEGENDS` |
+
+## API Documentation
+
+After building, generate and serve OpenAPI docs:
+```bash
+npm run docs:openapi     # Outputs to dist/openapi.json
+npm run dev              # Swagger UI available at /api-docs
+```

--- a/src/services/round-scheduler.service.ts
+++ b/src/services/round-scheduler.service.ts
@@ -38,7 +38,8 @@ class RoundSchedulerService {
     logger.info("[Round Scheduler] Stopped");
   }
 
-  private async createRound(): Promise<void> {
+  /** @visibleForTesting */
+  async createRound(): Promise<void> {
     try {
       const startPrice = priceOracle.getPrice();
 
@@ -84,7 +85,8 @@ class RoundSchedulerService {
     }
   }
 
-  private async closeEligibleRounds(): Promise<void> {
+  /** @visibleForTesting */
+  async closeEligibleRounds(): Promise<void> {
     try {
       const now = new Date();
 
@@ -107,7 +109,8 @@ class RoundSchedulerService {
     }
   }
 
-  private getMode(): "UP_DOWN" | "LEGENDS" {
+  /** @visibleForTesting */
+  getMode(): "UP_DOWN" | "LEGENDS" {
     const mode = process.env.ROUND_SCHEDULER_MODE || "UP_DOWN";
     if (mode === "LEGENDS") {
       return "LEGENDS";

--- a/src/services/scheduler.service.ts
+++ b/src/services/scheduler.service.ts
@@ -115,8 +115,9 @@ class SchedulerService {
 
   /**
    * Cleanup old notifications (older than 30 days)
+   * @visibleForTesting
    */
-  private async cleanupOldNotifications(): Promise<void> {
+  async cleanupOldNotifications(): Promise<void> {
     try {
       const deletedCount =
         await notificationService.cleanupOldNotifications(30);

--- a/src/tests/round-scheduler.service.spec.ts
+++ b/src/tests/round-scheduler.service.spec.ts
@@ -1,0 +1,332 @@
+// Mocks must be declared before any imports — ts-jest hoists these calls.
+
+jest.mock("node-cron", () => ({
+  schedule: jest.fn().mockReturnValue({ stop: jest.fn() }),
+}));
+
+jest.mock("../services/oracle", () => ({
+  __esModule: true,
+  default: {
+    getPrice: jest.fn(),
+    isStale: jest.fn(),
+  },
+}));
+
+jest.mock("../services/round.service", () => ({
+  __esModule: true,
+  default: {
+    startRound: jest.fn(),
+    autoLockExpiredRounds: jest.fn(),
+  },
+}));
+
+/**
+ * Mock Prisma so these unit tests run without a real database.
+ * `closeEligibleRounds` and `createRound` each only touch one method on
+ * `prisma.round`, making a targeted mock straightforward.
+ */
+jest.mock("../lib/prisma", () => ({
+  prisma: {
+    round: {
+      findFirst: jest.fn(),
+      count: jest.fn(),
+    },
+    $disconnect: jest.fn(),
+  },
+}));
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals";
+import { prisma } from "../lib/prisma";
+import roundSchedulerService from "../services/round-scheduler.service";
+import roundService from "../services/round.service";
+import priceOracle from "../services/oracle";
+import cron from "node-cron";
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("RoundSchedulerService", () => {
+  // ── start() ─────────────────────────────────────────────────────────────────
+
+  describe("start()", () => {
+    afterEach(() => {
+      roundSchedulerService.stop();
+      delete process.env.ROUND_SCHEDULER_ENABLED;
+    });
+
+    it("does not schedule tasks when ROUND_SCHEDULER_ENABLED is not set", () => {
+      roundSchedulerService.start();
+
+      expect(cron.schedule).not.toHaveBeenCalled();
+    });
+
+    it('does not schedule tasks when ROUND_SCHEDULER_ENABLED is "false"', () => {
+      process.env.ROUND_SCHEDULER_ENABLED = "false";
+
+      roundSchedulerService.start();
+
+      expect(cron.schedule).not.toHaveBeenCalled();
+    });
+
+    it('schedules two tasks when ROUND_SCHEDULER_ENABLED is "true"', () => {
+      process.env.ROUND_SCHEDULER_ENABLED = "true";
+
+      roundSchedulerService.start();
+
+      expect(cron.schedule).toHaveBeenCalledTimes(2);
+    });
+
+    it("schedules round creation on the 4-minute mark", () => {
+      process.env.ROUND_SCHEDULER_ENABLED = "true";
+
+      roundSchedulerService.start();
+
+      expect(cron.schedule).toHaveBeenCalledWith(
+        "0 */4 * * * *",
+        expect.any(Function),
+      );
+    });
+
+    it("schedules the close-eligible-rounds check every 30 seconds", () => {
+      process.env.ROUND_SCHEDULER_ENABLED = "true";
+
+      roundSchedulerService.start();
+
+      expect(cron.schedule).toHaveBeenCalledWith(
+        "*/30 * * * * *",
+        expect.any(Function),
+      );
+    });
+  });
+
+  // ── getMode() ────────────────────────────────────────────────────────────────
+
+  describe("getMode()", () => {
+    afterEach(() => {
+      delete process.env.ROUND_SCHEDULER_MODE;
+    });
+
+    it("defaults to UP_DOWN when ROUND_SCHEDULER_MODE is not set", () => {
+      expect(roundSchedulerService.getMode()).toBe("UP_DOWN");
+    });
+
+    it("returns LEGENDS when ROUND_SCHEDULER_MODE is LEGENDS", () => {
+      process.env.ROUND_SCHEDULER_MODE = "LEGENDS";
+
+      expect(roundSchedulerService.getMode()).toBe("LEGENDS");
+    });
+
+    it("falls back to UP_DOWN for any unrecognised value", () => {
+      process.env.ROUND_SCHEDULER_MODE = "INVALID";
+
+      expect(roundSchedulerService.getMode()).toBe("UP_DOWN");
+    });
+  });
+
+  // ── createRound() ────────────────────────────────────────────────────────────
+  //
+  // Decision logic under test:
+  //   oracle null/zero/negative → skip
+  //   oracle stale              → skip
+  //   DB has active round       → skip
+  //   clean state               → delegate to roundService.startRound
+  //   startRound throws ACTIVE_ROUND_EXISTS → info log, no rethrow
+  //   startRound throws unknown error       → error log, no rethrow
+
+  describe("createRound()", () => {
+    beforeEach(() => {
+      delete process.env.ROUND_SCHEDULER_MODE;
+
+      // Healthy oracle defaults — individual tests override as needed.
+      (priceOracle.getPrice as any).mockReturnValue(0.35);
+      (priceOracle.isStale as any).mockReturnValue(false);
+
+      // DB: no active round by default.
+      (prisma.round.findFirst as any).mockResolvedValue(null);
+
+      (roundService.startRound as any).mockResolvedValue({ id: "mock-round" });
+    });
+
+    afterEach(() => {
+      delete process.env.ROUND_SCHEDULER_MODE;
+    });
+
+    it("calls startRound with oracle price and 1-minute duration when all gates pass", async () => {
+      await roundSchedulerService.createRound();
+
+      expect(roundService.startRound).toHaveBeenCalledTimes(1);
+      expect(roundService.startRound).toHaveBeenCalledWith("UP_DOWN", 0.35, 1);
+    });
+
+    it("skips creation when oracle price is null", async () => {
+      (priceOracle.getPrice as any).mockReturnValue(null);
+
+      await roundSchedulerService.createRound();
+
+      expect(prisma.round.findFirst).not.toHaveBeenCalled();
+      expect(roundService.startRound).not.toHaveBeenCalled();
+    });
+
+    it("skips creation when oracle price is zero", async () => {
+      (priceOracle.getPrice as any).mockReturnValue(0);
+
+      await roundSchedulerService.createRound();
+
+      expect(roundService.startRound).not.toHaveBeenCalled();
+    });
+
+    it("skips creation when oracle price is negative", async () => {
+      (priceOracle.getPrice as any).mockReturnValue(-0.5);
+
+      await roundSchedulerService.createRound();
+
+      expect(roundService.startRound).not.toHaveBeenCalled();
+    });
+
+    it("skips creation when oracle data is stale", async () => {
+      (priceOracle.isStale as any).mockReturnValue(true);
+
+      await roundSchedulerService.createRound();
+
+      expect(prisma.round.findFirst).not.toHaveBeenCalled();
+      expect(roundService.startRound).not.toHaveBeenCalled();
+    });
+
+    it("skips creation when an active round for the same mode already exists", async () => {
+      (prisma.round.findFirst as any).mockResolvedValue({
+        id: "existing-round-id",
+        mode: "UP_DOWN",
+        status: "ACTIVE",
+      });
+
+      await roundSchedulerService.createRound();
+
+      expect(roundService.startRound).not.toHaveBeenCalled();
+    });
+
+    it("queries the DB with the correct mode filter", async () => {
+      await roundSchedulerService.createRound();
+
+      expect(prisma.round.findFirst).toHaveBeenCalledWith({
+        where: { mode: "UP_DOWN", status: "ACTIVE" },
+      });
+    });
+
+    it("does not throw when startRound raises ACTIVE_ROUND_EXISTS", async () => {
+      const err: any = new Error("An active UP_DOWN round already exists");
+      err.code = "ACTIVE_ROUND_EXISTS";
+      (roundService.startRound as any).mockRejectedValue(err);
+
+      await expect(roundSchedulerService.createRound()).resolves.not.toThrow();
+    });
+
+    it("does not throw when startRound raises an unexpected error", async () => {
+      (roundService.startRound as any).mockRejectedValue(
+        new Error("Network timeout"),
+      );
+
+      await expect(roundSchedulerService.createRound()).resolves.not.toThrow();
+    });
+
+    it("passes LEGENDS mode to startRound when ROUND_SCHEDULER_MODE is LEGENDS", async () => {
+      process.env.ROUND_SCHEDULER_MODE = "LEGENDS";
+
+      await roundSchedulerService.createRound();
+
+      expect(roundService.startRound).toHaveBeenCalledWith("LEGENDS", 0.35, 1);
+    });
+
+    it("queries the DB with LEGENDS mode when env is LEGENDS", async () => {
+      process.env.ROUND_SCHEDULER_MODE = "LEGENDS";
+
+      await roundSchedulerService.createRound();
+
+      expect(prisma.round.findFirst).toHaveBeenCalledWith({
+        where: { mode: "LEGENDS", status: "ACTIVE" },
+      });
+    });
+  });
+
+  // ── closeEligibleRounds() ────────────────────────────────────────────────────
+  //
+  // Decision logic under test:
+  //   count = 0             → autoLockExpiredRounds not called
+  //   count > 0             → autoLockExpiredRounds called once
+  //   autoLock throws       → graceful error log, no rethrow
+  //
+  // The service calls `new Date()` before passing it to the DB query, but
+  // since prisma is mocked the actual timestamp has no effect on outcomes.
+  // Fake timers are therefore not needed here.
+
+  describe("closeEligibleRounds()", () => {
+    beforeEach(() => {
+      (roundService.autoLockExpiredRounds as any).mockResolvedValue(undefined);
+      // Default: no expired rounds.
+      (prisma.round.count as any).mockResolvedValue(0);
+    });
+
+    it("does not call autoLockExpiredRounds when the expired-round count is zero", async () => {
+      (prisma.round.count as any).mockResolvedValue(0);
+
+      await roundSchedulerService.closeEligibleRounds();
+
+      expect(roundService.autoLockExpiredRounds).not.toHaveBeenCalled();
+    });
+
+    it("calls autoLockExpiredRounds once when expired ACTIVE rounds exist", async () => {
+      (prisma.round.count as any).mockResolvedValue(3);
+
+      await roundSchedulerService.closeEligibleRounds();
+
+      expect(roundService.autoLockExpiredRounds).toHaveBeenCalledTimes(1);
+    });
+
+    it("queries the DB filtering only ACTIVE status with lte endTime", async () => {
+      (prisma.round.count as any).mockResolvedValue(1);
+
+      await roundSchedulerService.closeEligibleRounds();
+
+      expect(prisma.round.count).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            status: "ACTIVE",
+            endTime: expect.objectContaining({ lte: expect.any(Date) }),
+          }),
+        }),
+      );
+    });
+
+    it("does not throw when autoLockExpiredRounds fails", async () => {
+      (prisma.round.count as any).mockResolvedValue(2);
+      (roundService.autoLockExpiredRounds as any).mockRejectedValue(
+        new Error("DB connection lost"),
+      );
+
+      await expect(
+        roundSchedulerService.closeEligibleRounds(),
+      ).resolves.not.toThrow();
+    });
+
+    it("does not call autoLock when count is exactly zero", async () => {
+      (prisma.round.count as any).mockResolvedValue(0);
+
+      await roundSchedulerService.closeEligibleRounds();
+
+      expect(roundService.autoLockExpiredRounds).not.toHaveBeenCalled();
+    });
+
+    it("calls autoLock when count is exactly one", async () => {
+      (prisma.round.count as any).mockResolvedValue(1);
+
+      await roundSchedulerService.closeEligibleRounds();
+
+      expect(roundService.autoLockExpiredRounds).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/tests/scheduler.service.spec.ts
+++ b/src/tests/scheduler.service.spec.ts
@@ -1,0 +1,414 @@
+// Mocks must be declared before any imports — ts-jest hoists these calls.
+
+jest.mock("node-cron", () => ({
+  schedule: jest.fn().mockReturnValue({ stop: jest.fn() }),
+}));
+
+jest.mock("../services/oracle", () => ({
+  __esModule: true,
+  default: {
+    getPrice: jest.fn(),
+    isStale: jest.fn(),
+  },
+}));
+
+jest.mock("../services/resolution.service", () => ({
+  __esModule: true,
+  default: {
+    resolveRound: jest.fn(),
+  },
+}));
+
+jest.mock("../services/notification.service", () => ({
+  __esModule: true,
+  default: {
+    cleanupOldNotifications: jest.fn(),
+  },
+}));
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  afterAll,
+  jest,
+} from "@jest/globals";
+import { prisma } from "../lib/prisma";
+import schedulerService from "../services/scheduler.service";
+import resolutionService from "../services/resolution.service";
+import priceOracle from "../services/oracle";
+import notificationService from "../services/notification.service";
+import cron from "node-cron";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type RoundStatus = "ACTIVE" | "LOCKED" | "RESOLVED" | "CANCELLED";
+
+interface RoundFixtureOptions {
+  status?: RoundStatus;
+  endTime?: Date;
+  mode?: "UP_DOWN" | "LEGENDS";
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/**
+ * Fixed reference point. All endTime values are expressed relative to this so
+ * tests are insensitive to wall-clock time.
+ */
+const FAKE_NOW = new Date("2025-06-01T10:00:00.000Z");
+
+/**
+ * The 15-second buffer the service uses to avoid resolving rounds before price
+ * data has stabilised.
+ */
+const BUFFER_MS = 15_000;
+
+/**
+ * Only fake `Date`; keep all timer functions real so that Prisma's async
+ * machinery (Promises, keepalive timeouts, etc.) is unaffected.
+ */
+const FAKE_TIMER_OPTIONS: Parameters<typeof jest.useFakeTimers>[0] = {
+  doNotFake: [
+    "nextTick",
+    "queueMicrotask",
+    "setImmediate",
+    "clearImmediate",
+    "setTimeout",
+    "clearTimeout",
+    "setInterval",
+    "clearInterval",
+  ],
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("SchedulerService", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  // ── start() ─────────────────────────────────────────────────────────────────
+
+  describe("start()", () => {
+    afterEach(() => {
+      schedulerService.stop();
+      delete process.env.AUTO_RESOLVE_ENABLED;
+      delete process.env.AUTO_RESOLVE_INTERVAL_SECONDS;
+    });
+
+    it("does not schedule tasks when AUTO_RESOLVE_ENABLED is not set", () => {
+      schedulerService.start();
+
+      expect(cron.schedule).not.toHaveBeenCalled();
+    });
+
+    it('does not schedule tasks when AUTO_RESOLVE_ENABLED is "false"', () => {
+      process.env.AUTO_RESOLVE_ENABLED = "false";
+
+      schedulerService.start();
+
+      expect(cron.schedule).not.toHaveBeenCalled();
+    });
+
+    it('schedules exactly two tasks when AUTO_RESOLVE_ENABLED is "true"', () => {
+      process.env.AUTO_RESOLVE_ENABLED = "true";
+
+      schedulerService.start();
+
+      expect(cron.schedule).toHaveBeenCalledTimes(2);
+    });
+
+    it("uses the default 30-second interval in the auto-resolve cron expression", () => {
+      process.env.AUTO_RESOLVE_ENABLED = "true";
+
+      schedulerService.start();
+
+      expect(cron.schedule).toHaveBeenCalledWith(
+        "*/30 * * * * *",
+        expect.any(Function),
+      );
+    });
+
+    it("uses a custom interval from AUTO_RESOLVE_INTERVAL_SECONDS", () => {
+      process.env.AUTO_RESOLVE_ENABLED = "true";
+      process.env.AUTO_RESOLVE_INTERVAL_SECONDS = "60";
+
+      schedulerService.start();
+
+      expect(cron.schedule).toHaveBeenCalledWith(
+        "*/60 * * * * *",
+        expect.any(Function),
+      );
+    });
+
+    it("schedules the daily cleanup job at 2:00 AM", () => {
+      process.env.AUTO_RESOLVE_ENABLED = "true";
+
+      schedulerService.start();
+
+      expect(cron.schedule).toHaveBeenCalledWith(
+        "0 2 * * *",
+        expect.any(Function),
+      );
+    });
+  });
+
+  // ── autoResolveRounds() ─────────────────────────────────────────────────────
+
+  describe("autoResolveRounds()", () => {
+    const createdRoundIds = new Set<string>();
+
+    /**
+     * Creates a Round fixture whose endTime is expressed relative to FAKE_NOW.
+     * All IDs are tracked for cleanup in afterEach.
+     */
+    async function createRound(options: RoundFixtureOptions = {}) {
+      const {
+        status = "ACTIVE",
+        mode = "UP_DOWN",
+        endTime = new Date(FAKE_NOW.getTime() - BUFFER_MS - 1_000),
+      } = options;
+
+      const round = await prisma.round.create({
+        data: {
+          mode,
+          status,
+          startPrice: 0.3,
+          startTime: new Date(FAKE_NOW.getTime() - 120_000),
+          endTime,
+          poolUp: 0,
+          poolDown: 0,
+        },
+      });
+
+      createdRoundIds.add(round.id);
+      return round;
+    }
+
+    beforeEach(() => {
+      jest.useFakeTimers(FAKE_TIMER_OPTIONS);
+      jest.setSystemTime(FAKE_NOW);
+
+      // Healthy oracle defaults — individual tests override as needed.
+      (priceOracle.getPrice as any).mockReturnValue(0.35);
+      (priceOracle.isStale as any).mockReturnValue(false);
+      (resolutionService.resolveRound as any).mockResolvedValue(undefined);
+    });
+
+    afterEach(async () => {
+      jest.useRealTimers();
+
+      if (createdRoundIds.size > 0) {
+        await prisma.round.deleteMany({
+          where: { id: { in: [...createdRoundIds] } },
+        });
+        createdRoundIds.clear();
+      }
+    });
+
+    it("does nothing when no expired rounds exist", async () => {
+      await schedulerService.autoResolveRounds();
+
+      expect(resolutionService.resolveRound).not.toHaveBeenCalled();
+    });
+
+    it("resolves an ACTIVE round that has passed the 15-second buffer", async () => {
+      const round = await createRound({
+        status: "ACTIVE",
+        endTime: new Date(FAKE_NOW.getTime() - BUFFER_MS - 1),
+      });
+
+      await schedulerService.autoResolveRounds();
+
+      expect(resolutionService.resolveRound).toHaveBeenCalledTimes(1);
+      expect(resolutionService.resolveRound).toHaveBeenCalledWith(
+        round.id,
+        0.35,
+      );
+    });
+
+    it("resolves a LOCKED round that has passed the buffer", async () => {
+      const round = await createRound({
+        status: "LOCKED",
+        endTime: new Date(FAKE_NOW.getTime() - BUFFER_MS - 1),
+      });
+
+      await schedulerService.autoResolveRounds();
+
+      expect(resolutionService.resolveRound).toHaveBeenCalledWith(
+        round.id,
+        0.35,
+      );
+    });
+
+    it("does not resolve a round whose endTime is still within the buffer window", async () => {
+      // endTime is 14 seconds ago — within the 15-second buffer.
+      await createRound({
+        status: "ACTIVE",
+        endTime: new Date(FAKE_NOW.getTime() - BUFFER_MS + 1_000),
+      });
+
+      await schedulerService.autoResolveRounds();
+
+      expect(resolutionService.resolveRound).not.toHaveBeenCalled();
+    });
+
+    it("does not resolve a round whose endTime is in the future", async () => {
+      await createRound({
+        status: "ACTIVE",
+        endTime: new Date(FAKE_NOW.getTime() + 30_000),
+      });
+
+      await schedulerService.autoResolveRounds();
+
+      expect(resolutionService.resolveRound).not.toHaveBeenCalled();
+    });
+
+    it("skips all resolution when the oracle price is null", async () => {
+      (priceOracle.getPrice as any).mockReturnValue(null);
+      await createRound();
+
+      await schedulerService.autoResolveRounds();
+
+      expect(resolutionService.resolveRound).not.toHaveBeenCalled();
+    });
+
+    it("skips all resolution when the oracle price is zero", async () => {
+      (priceOracle.getPrice as any).mockReturnValue(0);
+      await createRound();
+
+      await schedulerService.autoResolveRounds();
+
+      expect(resolutionService.resolveRound).not.toHaveBeenCalled();
+    });
+
+    it("skips all resolution when the oracle price is negative", async () => {
+      (priceOracle.getPrice as any).mockReturnValue(-0.1);
+      await createRound();
+
+      await schedulerService.autoResolveRounds();
+
+      expect(resolutionService.resolveRound).not.toHaveBeenCalled();
+    });
+
+    it("skips all resolution when oracle data is stale", async () => {
+      (priceOracle.isStale as any).mockReturnValue(true);
+      await createRound();
+
+      await schedulerService.autoResolveRounds();
+
+      expect(resolutionService.resolveRound).not.toHaveBeenCalled();
+    });
+
+    it("continues resolving remaining rounds when one round fails", async () => {
+      const expiredAt = new Date(FAKE_NOW.getTime() - BUFFER_MS - 1);
+      const round1 = await createRound({ endTime: expiredAt });
+      const round2 = await createRound({ endTime: expiredAt });
+
+      (resolutionService.resolveRound as any)
+        .mockRejectedValueOnce(new Error("transient failure"))
+        .mockResolvedValueOnce(undefined);
+
+      await expect(schedulerService.autoResolveRounds()).resolves.not.toThrow();
+
+      expect(resolutionService.resolveRound).toHaveBeenCalledTimes(2);
+      const resolvedIds = (resolutionService.resolveRound as any).mock.calls.map(
+        (c: any[]) => c[0],
+      );
+      expect(resolvedIds).toContain(round1.id);
+      expect(resolvedIds).toContain(round2.id);
+    });
+
+    it("resolves all expired rounds in a single invocation", async () => {
+      const expiredAt = new Date(FAKE_NOW.getTime() - BUFFER_MS - 1);
+      const rounds = await Promise.all([
+        createRound({ endTime: expiredAt }),
+        createRound({ endTime: expiredAt }),
+        createRound({ endTime: expiredAt }),
+      ]);
+
+      await schedulerService.autoResolveRounds();
+
+      expect(resolutionService.resolveRound).toHaveBeenCalledTimes(3);
+      const resolvedIds = (resolutionService.resolveRound as any).mock.calls.map(
+        (c: any[]) => c[0],
+      );
+      for (const round of rounds) {
+        expect(resolvedIds).toContain(round.id);
+      }
+    });
+
+    it("does not include already-RESOLVED rounds", async () => {
+      await createRound({
+        status: "RESOLVED",
+        endTime: new Date(FAKE_NOW.getTime() - BUFFER_MS - 1),
+      });
+
+      await schedulerService.autoResolveRounds();
+
+      expect(resolutionService.resolveRound).not.toHaveBeenCalled();
+    });
+
+    it("does not include CANCELLED rounds", async () => {
+      await createRound({
+        status: "CANCELLED",
+        endTime: new Date(FAKE_NOW.getTime() - BUFFER_MS - 1),
+      });
+
+      await schedulerService.autoResolveRounds();
+
+      expect(resolutionService.resolveRound).not.toHaveBeenCalled();
+    });
+
+    it("handles the exact buffer boundary — 15000 ms past endTime is not yet eligible", async () => {
+      // bufferTime = now - 15000. A round that ended exactly 15000 ms ago has
+      // endTime = now - 15000 = bufferTime, so lte(bufferTime) IS true → eligible.
+      // A round that ended 14999 ms ago has endTime > bufferTime → ineligible.
+      const atBoundary = await createRound({
+        status: "ACTIVE",
+        endTime: new Date(FAKE_NOW.getTime() - BUFFER_MS), // exactly at bufferTime
+      });
+      const justInsideBuffer = await createRound({
+        status: "ACTIVE",
+        endTime: new Date(FAKE_NOW.getTime() - BUFFER_MS + 1), // 1ms inside buffer
+      });
+
+      await schedulerService.autoResolveRounds();
+
+      const resolvedIds = (resolutionService.resolveRound as any).mock.calls.map(
+        (c: any[]) => c[0],
+      );
+      // The round at exactly the boundary IS included (lte).
+      expect(resolvedIds).toContain(atBoundary.id);
+      // The round 1ms inside the buffer is NOT included.
+      expect(resolvedIds).not.toContain(justInsideBuffer.id);
+    });
+  });
+
+  // ── cleanupOldNotifications() ────────────────────────────────────────────────
+
+  describe("cleanupOldNotifications()", () => {
+    it("delegates to the notification service with a 30-day threshold", async () => {
+      (notificationService.cleanupOldNotifications as any).mockResolvedValue(7);
+
+      await schedulerService.cleanupOldNotifications();
+
+      expect(notificationService.cleanupOldNotifications).toHaveBeenCalledWith(
+        30,
+      );
+    });
+
+    it("does not throw when the notification service fails", async () => {
+      (notificationService.cleanupOldNotifications as any).mockRejectedValue(
+        new Error("DB connection lost"),
+      );
+
+      await expect(
+        schedulerService.cleanupOldNotifications(),
+      ).resolves.not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
Closes #79 

## Summary

- Add `scheduler.service.spec.ts` — 22 integration tests using real DB fixtures and fake `Date` to verify `autoResolveRounds()` status-transition logic and buffer-window boundaries
- Add `round-scheduler.service.spec.ts` — 25 pure unit tests (mocked Prisma, no DB required) covering `createRound()` oracle gates, existing-round deduplication, and `closeEligibleRounds()` decision logic
- Expose four private service methods with `@visibleForTesting` (minimal change, no API surface affected): `cleanupOldNotifications`, `createRound`, `closeEligibleRounds`, `getMode`

## Test plan

- [ ] `npx jest --testPathPattern="round-scheduler.service.spec"` → 25/25 pass (no DB needed)
- [ ] `npx jest --testPathPattern="scheduler.service.spec"` → all pass in CI with PostgreSQL service
- [ ] `npm test` → no regression in previously-passing suites
- [ ] Verify `start()` tests confirm cron tasks are not registered when scheduler env flags are unset

