### PR TITLE
Feature: Define the canonical authenticated request contract

### DIFF
--- a/src/types/auth.types.ts
+++ b/src/types/auth.types.ts
@@ -1,35 +1,45 @@
+import { Request } from "express";
+
 export interface ChallengeRequestBody {
-  walletAddress: string;
+    walletAddress: string;
 }
 
 export interface ChallengeResponse {
-  challenge: string;
-  expiresAt: string;
+    challenge: string;
+    expiresAt: string;
 }
 
 export interface ConnectRequestBody {
-  walletAddress: string;
-  challenge: string;
-  signature: string;
+    walletAddress: string;
+    challenge: string;
+    signature: string;
 }
 
 export interface ConnectResponse {
-  token: string;
-  user: {
-    id: string;
-    walletAddress: string;
-    createdAt: string;
-    lastLoginAt: string;
-  };
+    token: string;
+    user: {
+        id: string;
+        walletAddress: string;
+        createdAt: string;
+        lastLoginAt: string;
+    };
 }
 
 export interface JwtPayload {
-  userId: string;
-  walletAddress: string;
-  iat?: number;
-  exp?: number;
+    userId: string;
+    walletAddress: string;
+    role?: string;
+    iat?: number;
+    exp?: number;
+}
+
+export interface AuthenticatedUser {
+    userId: string;
+    walletAddress: string;
+    role?: string;
 }
 
 export interface AuthRequest extends Request {
-  user?: JwtPayload;
+    user?: AuthenticatedUser;
+    userId?: string;
 }


### PR DESCRIPTION
## Description

Introduce (or normalize) one shared auth shape used everywhere after JWT verification, instead of mixing `req.user.userId` and legacy `req.userId`.

## Changes

- `src/types/auth.types.ts` (modified)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Code follows the style guidelines of this project
- [x] Self-review of code completed
- [x] Changes generate no new warnings
- [ ] Corresponding changes to documentation made (if applicable)

**Severity**: `high`


Closes #108