### PR TITLE
feat(startup): support API-only mode without schedulers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,13 @@ ROUND_SCHEDULER_ENABLED=false
 # Game mode for scheduled rounds: UP_DOWN or LEGENDS
 ROUND_SCHEDULER_MODE=UP_DOWN
 
+# API-only startup mode (no background workers)
+# Set to "true" to run the HTTP API without oracle polling, cron schedulers,
+# or WebSocket price-tick broadcasts. Useful for split deployments
+# (one worker process owns crons; others serve HTTP) and for safer
+# local debugging when you don't want background jobs running.
+API_ONLY=false
+
 # Price Oracle Configuration
 # Interval between price updates from CoinGecko (milliseconds)
 ORACLE_POLLING_INTERVAL_MS=10000

--- a/README.md
+++ b/README.md
@@ -225,6 +225,12 @@ Xelma-Backend/
   - Locks rounds after 30 seconds (configurable)
   - Controlled by `ROUND_SCHEDULER_ENABLED` environment variable
 
+> **API-only mode**: Set `API_ONLY=true` to start the HTTP server with
+> all schedulers, oracle polling, and the WebSocket price ticker
+> disabled. This is the recommended setup for split deployments — one
+> dedicated worker process runs background jobs while one or more
+> stateless processes serve HTTP — and for safer local debugging.
+
 #### **9. Notification Service (`notification.service.ts`)**
 - **Purpose**: Creates and delivers notifications to users
 - **Types**: WIN, LOSS, ROUND_START, BONUS_AVAILABLE, ANNOUNCEMENT
@@ -431,6 +437,9 @@ SOROBAN_ORACLE_SECRET=S...your-oracle-secret-key
 # Round Scheduler
 ROUND_SCHEDULER_ENABLED=false  # Set to 'true' to enable automated rounds
 ROUND_SCHEDULER_MODE=UP_DOWN   # or 'LEGENDS'
+
+# API-only startup mode (skip oracle polling, schedulers, and price ticker)
+API_ONLY=false  # Set to 'true' to run as a stateless HTTP API only
 
 # Price Oracle Configuration
 ORACLE_POLLING_INTERVAL_MS=10000    # Interval between price updates (ms)

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -12,6 +12,7 @@ export interface AppConfig {
   nodeEnv: "development" | "production" | "test";
   clientUrl: string;
   logLevel: string;
+  apiOnly: boolean;
 }
 
 export interface JwtConfig {
@@ -92,6 +93,7 @@ function buildConfig(): Config {
       ["error", "warn", "info", "http", "verbose", "debug", "silly"] as const,
       "info",
     ),
+    apiOnly: v.boolean(env.API_ONLY, false),
   };
 
   const jwt: JwtConfig = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -242,37 +242,64 @@ interface ServerHandle {
 }
 
 /**
+ * Returns true when the process should run as a stateless API only —
+ * no oracle polling, no cron schedulers, no WebSocket price ticker.
+ * Useful for split deployments where one process owns background work
+ * and others serve HTTP, and for safer local debugging.
+ */
+export function isApiOnlyMode(): boolean {
+  const raw = process.env.API_ONLY;
+  if (!raw) return false;
+  return raw.toLowerCase() === "true";
+}
+
+/**
  * Start background services, bind to a port, and return a handle that
  * can be used to shut everything down cleanly.
+ *
+ * When API_ONLY=true, schedulers, oracle polling, and the WebSocket
+ * price ticker are skipped. The HTTP server (and Socket.IO transport)
+ * still come up, so request-driven endpoints remain available.
  */
 export function startServer(app: Express): ServerHandle {
   const PORT = process.env.PORT || 3000;
   const httpServer = createServer(app);
+  const apiOnly = isApiOnlyMode();
 
   // Initialize Socket.IO with JWT authentication
   initializeSocket(httpServer);
 
-  // Start Oracle Polling
-  priceOracle.startPolling();
+  let priceInterval: NodeJS.Timeout | null = null;
 
-  // Initialize Schedulers
-  schedulerService.start();
-  roundSchedulerService.start();
+  if (apiOnly) {
+    logger.info("API_ONLY=true: skipping oracle polling, schedulers, and WebSocket price ticker");
+  } else {
+    // Start Oracle Polling
+    priceOracle.startPolling();
 
-  // Emit price updates via WebSocket
-  const priceInterval = setInterval(() => {
-    const price = priceOracle.getPriceString();
-    if (price !== null) {
-      websocketService.emitPriceUpdate("XLM", price);
-    }
-  }, 5000);
+    // Initialize Schedulers
+    schedulerService.start();
+    roundSchedulerService.start();
+
+    // Emit price updates via WebSocket
+    priceInterval = setInterval(() => {
+      const price = priceOracle.getPriceString();
+      if (price !== null) {
+        websocketService.emitPriceUpdate("XLM", price);
+      }
+    }, 5000);
+  }
 
   const cleanup = async () => {
     logger.info("Shutting down gracefully...");
-    clearInterval(priceInterval);
-    priceOracle.stopPolling();
-    schedulerService.stop();
-    roundSchedulerService.stop();
+    if (priceInterval) {
+      clearInterval(priceInterval);
+    }
+    if (!apiOnly) {
+      priceOracle.stopPolling();
+      schedulerService.stop();
+      roundSchedulerService.stop();
+    }
     httpServer.close();
     await prisma.$disconnect();
     logger.info("Shutdown complete");

--- a/src/tests/api-only-mode.spec.ts
+++ b/src/tests/api-only-mode.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+
+describe("isApiOnlyMode()", () => {
+  let originalApiOnly: string | undefined;
+
+  beforeEach(() => {
+    originalApiOnly = process.env.API_ONLY;
+    delete process.env.API_ONLY;
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalApiOnly === undefined) {
+      delete process.env.API_ONLY;
+    } else {
+      process.env.API_ONLY = originalApiOnly;
+    }
+    jest.resetModules();
+  });
+
+  it("returns false when API_ONLY is unset", () => {
+    const { isApiOnlyMode } = require("../index");
+    expect(isApiOnlyMode()).toBe(false);
+  });
+
+  it('returns true when API_ONLY is "true"', () => {
+    process.env.API_ONLY = "true";
+    const { isApiOnlyMode } = require("../index");
+    expect(isApiOnlyMode()).toBe(true);
+  });
+
+  it('returns true when API_ONLY is "TRUE" (case-insensitive)', () => {
+    process.env.API_ONLY = "TRUE";
+    const { isApiOnlyMode } = require("../index");
+    expect(isApiOnlyMode()).toBe(true);
+  });
+
+  it('returns false when API_ONLY is "false"', () => {
+    process.env.API_ONLY = "false";
+    const { isApiOnlyMode } = require("../index");
+    expect(isApiOnlyMode()).toBe(false);
+  });
+
+  it("returns false for arbitrary non-true values", () => {
+    process.env.API_ONLY = "1";
+    const { isApiOnlyMode } = require("../index");
+    expect(isApiOnlyMode()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an `API_ONLY` environment variable so the HTTP server can boot without any background workers. When `API_ONLY=true`, oracle polling, the general `scheduler.service` cron jobs, the `round-scheduler.service` cron jobs, and the WebSocket price ticker are all skipped — but the HTTP server and Socket.IO transport still come up, so request-driven endpoints remain available. This enables split deployments (one worker process owns the crons; one or more stateless processes serve HTTP) and makes local debugging safer when you do not want background jobs running.

closes #173

## Changes
- **#173 — API-only startup mode**:
  - src/index.ts: New isApiOnlyMode() reads API_ONLY (case-insensitive "true"; default false). startServer() now branches on it — when on, it logs and skips priceOracle.startPolling(), schedulerService.start(), roundSchedulerService.start(), and the 5-second setInterval that emits XLM price updates over WebSocket. The matching cleanup() paths are guarded so shutdown stays a no-op for things that were never started.
  - src/config/index.ts: Adds apiOnly: boolean to AppConfig and parses API_ONLY via the existing v.boolean(...) validator (default false).
  - .env.example and README.md: Document the new API_ONLY flag, including the split-deployment / local-debug rationale.
  - src/tests/api-only-mode.spec.ts: New unit tests for isApiOnlyMode() covering unset, "true", "TRUE" (case-insensitive), "false", and arbitrary non-true values.

## Test plan
- npm run lint — passes (tsc --noEmit clean)
- npm run build — passes
- npx jest src/tests/api-only-mode.spec.ts — 5/5 passing locally
- Existing scheduler tests untouched; behavior in the default (API_ONLY unset / false) path is unchanged.

## Risk notes
- Backward compatible — existing deployments that do not set API_ONLY see no behavior change.
- validateEnv() and createApp() are unaffected; only the optional startServer() path branches.
- Socket.IO is intentionally still initialized in API-only mode (clients can still connect for non-price events); only the server-driven 5-second price emission is suppressed.
