### PR TITLE
feat(startup): Render-parity profile, bindings validation, and CORS diagnostics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,11 @@
 # Server Configuration
+# ─────────────────────────────────────────────────────────────────────────────
+# To reproduce Render production behavior locally, see the
+# "Render parity local profile" section of README.md and use
+# `npm run start:render-parity`. That mode requires the same vars
+# Render uses: NODE_ENV=production, CLIENT_URL set (no wildcard CORS),
+# JWT_SECRET, DATABASE_URL, plus the SOROBAN_* secrets if Soroban is on.
+# ─────────────────────────────────────────────────────────────────────────────
 PORT=3000
 NODE_ENV=development
 

--- a/README.md
+++ b/README.md
@@ -504,6 +504,41 @@ npm run build
 npm start
 ```
 
+### Render Parity Local Profile
+
+To reproduce the runtime behavior of the Render deployment on your machine,
+use the `start:render-parity` script. This sets `NODE_ENV=production`
+before launching the built server so the same code paths Render hits
+fire locally — CORS is strict (`CLIENT_URL` must be set, no wildcard
+origin), error responses match production, and logging runs at
+production verbosity.
+
+```bash
+# 1) Build first (start:render-parity expects dist/)
+npm run build
+
+# 2) Run with production-shaped environment
+CLIENT_URL=http://localhost:5173 \
+JWT_SECRET="$(openssl rand -base64 32)" \
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/xelma_local" \
+npm run start:render-parity
+```
+
+Required env vars for parity (matches what Render's environment supplies):
+
+| Variable | Why it matters in render-parity mode |
+|---|---|
+| `NODE_ENV=production` | Set by the script. Enables strict CORS and production logging. |
+| `CLIENT_URL` | **Required.** Strict CORS will reject all origins if unset. |
+| `ALLOWED_ORIGINS` | Optional comma-separated extra origins. |
+| `JWT_SECRET` | Required for startup. Use a cryptographically strong value. |
+| `DATABASE_URL` | Required. Point at a local Postgres. |
+| `SOROBAN_CONTRACT_ID` / `SOROBAN_ADMIN_SECRET` / `SOROBAN_ORACLE_SECRET` | Optional; only needed if you want on-chain calls. |
+
+If you hit a CORS error from your frontend in this mode, hit
+`GET /api/admin/cors-diagnostics?origin=<your-origin>` with an admin
+token to see exactly which origins this process accepts.
+
 ### Verify Server is Running
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -556,6 +556,36 @@ Expected response:
 
 ---
 
+### Dead-letter queue for failed notifications and events
+
+Notification creation and WebSocket emits go through a dead-letter queue
+(DLQ) so a transient DB blip, a not-yet-initialized socket layer, or a
+runtime exception in `emit` does not silently drop a user-facing event.
+
+How it works:
+
+- `notificationService.createNotification(...)` records a `FailedDispatch`
+  row on `NOTIFICATION_CREATE` errors (the original error still rethrows
+  so callers behave the same).
+- `websocketService.emit*(...)` records a `FailedDispatch` row whenever
+  the socket layer is not initialized or the underlying `emit` throws.
+  The emit itself is fire-and-forget — the caller's hot path is never
+  broken by a DLQ persistence failure.
+- Rows have `attempts`, `lastError`, and `status` (`PENDING`, `RETRYING`,
+  `RESOLVED`, `ABANDONED`) so an operator can triage stuck dispatches.
+
+Operator endpoints (admin-only, gated by `requireAdmin`):
+
+- `GET  /api/admin/dead-letter` — list entries, newest first. Query
+  params: `status`, `channel`, `limit`, `offset`.
+- `POST /api/admin/dead-letter/:id/retry` — replay a single entry; sets
+  `RESOLVED` on success, bumps `attempts` and moves to `ABANDONED` once
+  the cap (default 5) is reached.
+- `POST /api/admin/dead-letter/retry-all` — replay every `PENDING` /
+  `RETRYING` entry (capped, oldest first). Returns a counts summary.
+
+---
+
 ## API Documentation
 
 The backend provides auto-generated **OpenAPI/Swagger** documentation.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "install-bindings": "node scripts/install-bindings.js",
     "preinstall": "node scripts/install-bindings.js || true",
     "postinstall": "npm run build",
+    "start:render-parity": "NODE_ENV=production node dist/index.js",
     "docs:openapi": "node dist/scripts/generate-openapi.js",
     "docs:postman": "node dist/scripts/export-postman.js",
     "prisma:generate": "prisma generate",

--- a/prisma/migrations/20260530000000_add_failed_dispatch_dlq/migration.sql
+++ b/prisma/migrations/20260530000000_add_failed_dispatch_dlq/migration.sql
@@ -1,0 +1,35 @@
+-- CreateEnum
+CREATE TYPE "DispatchChannel" AS ENUM ('NOTIFICATION_CREATE', 'WEBSOCKET_EMIT');
+
+-- CreateEnum
+CREATE TYPE "DispatchStatus" AS ENUM ('PENDING', 'RETRYING', 'RESOLVED', 'ABANDONED');
+
+-- CreateTable
+CREATE TABLE "FailedDispatch" (
+    "id" TEXT NOT NULL,
+    "channel" "DispatchChannel" NOT NULL,
+    "eventName" TEXT,
+    "userId" TEXT,
+    "payload" JSONB NOT NULL,
+    "attempts" INTEGER NOT NULL DEFAULT 1,
+    "status" "DispatchStatus" NOT NULL DEFAULT 'PENDING',
+    "lastError" VARCHAR(1000) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "lastRetryAt" TIMESTAMP(3),
+    "resolvedAt" TIMESTAMP(3),
+
+    CONSTRAINT "FailedDispatch_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "FailedDispatch_channel_idx" ON "FailedDispatch"("channel");
+
+-- CreateIndex
+CREATE INDEX "FailedDispatch_status_idx" ON "FailedDispatch"("status");
+
+-- CreateIndex
+CREATE INDEX "FailedDispatch_createdAt_idx" ON "FailedDispatch"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "FailedDispatch_userId_idx" ON "FailedDispatch"("userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,6 +51,18 @@ enum TransactionType {
   DEPOSIT
 }
 
+enum DispatchChannel {
+  NOTIFICATION_CREATE
+  WEBSOCKET_EMIT
+}
+
+enum DispatchStatus {
+  PENDING
+  RETRYING
+  RESOLVED
+  ABANDONED
+}
+
 // =======================
 // Models
 // =======================
@@ -205,6 +217,31 @@ model Transaction {
 
   @@index([userId])
   @@index([type])
+}
+
+/// Dead-letter queue row for a notification or websocket dispatch that
+/// failed at runtime. Keeps the original payload so an operator (or a
+/// scheduled retry job) can replay the dispatch later without losing the
+/// signal. `attempts` and `lastError` track how the entry has aged so a
+/// stuck row can be triaged from `/api/admin/dead-letter`.
+model FailedDispatch {
+  id        String          @id @default(uuid())
+  channel   DispatchChannel
+  eventName String?
+  userId    String?
+  payload   Json
+  attempts  Int             @default(1)
+  status    DispatchStatus  @default(PENDING)
+  lastError String          @db.VarChar(1000)
+  createdAt DateTime        @default(now())
+  updatedAt DateTime        @updatedAt
+  lastRetryAt DateTime?
+  resolvedAt  DateTime?
+
+  @@index([channel])
+  @@index([status])
+  @@index([createdAt])
+  @@index([userId])
 }
 
 model RateLimitMetric {

--- a/scripts/install-bindings.js
+++ b/scripts/install-bindings.js
@@ -56,6 +56,15 @@ function main() {
     run(`git fetch --depth=1 origin ${BRANCH}`, tmp);
     run("git checkout FETCH_HEAD", tmp);
 
+    let commitSha = "";
+    try {
+      commitSha = execSync("git rev-parse HEAD", { cwd: tmp })
+        .toString()
+        .trim();
+    } catch (e) {
+      console.warn("[install-bindings] could not resolve upstream SHA:", e.message);
+    }
+
     const srcDir = path.join(tmp, SUBDIR);
 
     console.log("[install-bindings] Installing bindings dependencies…");
@@ -81,6 +90,12 @@ function main() {
 
     // Patch the package.json: rename to @tevalabs/xelma-bindings and add CJS export
     patchPackageJson(path.join(DEST, "package.json"));
+
+    // Record the resolved upstream SHA so the runtime validator can surface
+    // the vendor version at startup (see src/utils/bindings-validator.ts).
+    if (commitSha) {
+      fs.writeFileSync(path.join(DEST, ".commit-sha"), `${commitSha}\n`);
+    }
 
     console.log("[install-bindings] Done ✓");
   } finally {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { requestIdMiddleware } from './middleware/requestId.middleware';
 import metricsRoutes from './routes/metrics.routes';
 import adminMetricsRoutes from './routes/admin-metrics.routes';
 import corsDiagnosticsRoutes from './routes/admin-cors-diagnostics.routes';
+import deadLetterRoutes from './routes/admin-dead-letter.routes';
 import chatRoutes from "./routes/chat.routes";
 import swaggerUi from 'swagger-ui-express';
 import { swaggerSpec } from './docs/openapi';
@@ -135,6 +136,7 @@ export function createApp(): Express {
   app.use("/api/notifications", notificationsRoutes);
   app.use("/api/admin/metrics", adminMetricsRoutes);
   app.use("/api/admin/cors-diagnostics", corsDiagnosticsRoutes);
+  app.use("/api/admin/dead-letter", deadLetterRoutes);
 
   // Prometheus metrics endpoint
   app.use('/metrics', metricsRoutes);

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,11 +15,13 @@ import websocketService from './services/websocket.service';
 import schedulerService from './services/scheduler.service';
 import roundSchedulerService from './services/round-scheduler.service';
 import logger from './utils/logger';
+import { validateVendoredBindings } from './utils/bindings-validator';
 import { errorHandler } from './middleware/errorHandler.middleware';
 import { metricsMiddleware } from './middleware/metrics.middleware';
 import { requestIdMiddleware } from './middleware/requestId.middleware';
 import metricsRoutes from './routes/metrics.routes';
 import adminMetricsRoutes from './routes/admin-metrics.routes';
+import corsDiagnosticsRoutes from './routes/admin-cors-diagnostics.routes';
 import chatRoutes from "./routes/chat.routes";
 import swaggerUi from 'swagger-ui-express';
 import { swaggerSpec } from './docs/openapi';
@@ -31,39 +33,8 @@ const envFile = process.env.NODE_ENV === 'test' ? '.env.test' : '.env';
 dotenv.config({ path: path.resolve(process.cwd(), envFile), override: false });
 dotenv.config({ override: false });
 
-/**
- * Resolve the CORS origin allowlist for Express HTTP routes.
- * Mirrors the logic in socket.ts getCorsOrigins() so both layers
- * enforce the same policy.
- */
-export function getHttpCorsOrigins(): string | string[] | boolean {
-  const clientUrl = process.env.CLIENT_URL;
-  const isProduction = process.env.NODE_ENV === 'production';
-
-  if (isProduction) {
-    if (!clientUrl) {
-      throw new Error(
-        'CLIENT_URL environment variable is required in production. ' +
-        'HTTP CORS cannot use wildcard origin (*) in production.',
-      );
-    }
-    const additional = process.env.ALLOWED_ORIGINS;
-    if (additional) {
-      return [clientUrl, ...additional.split(',').map((o) => o.trim()).filter(Boolean)];
-    }
-    return clientUrl;
-  }
-
-  if (!clientUrl) {
-    return true; // Allow all origins in development when CLIENT_URL is unset
-  }
-
-  const additional = process.env.ALLOWED_ORIGINS;
-  if (additional) {
-    return [clientUrl, ...additional.split(',').map((o) => o.trim()).filter(Boolean)];
-  }
-  return clientUrl;
-}
+export { getHttpCorsOrigins } from './utils/cors';
+import { getHttpCorsOrigins } from './utils/cors';
 
 /**
  * Apply security headers to every response.
@@ -89,8 +60,35 @@ const validateEnv = (): void => {
   }
 };
 
+/**
+ * Validate the vendored @tevalabs/xelma-bindings package at startup so a
+ * stale or partial vendor surfaces immediately, instead of as an opaque
+ * "Cannot find module" deep inside the Soroban service later. Only logs —
+ * never throws — because API-only deployments may run without Soroban.
+ */
+function logBindingsValidation(): void {
+  const result = validateVendoredBindings();
+  if (result.ok) {
+    logger.info('Vendored bindings OK', {
+      vendorPath: result.info.vendorPath,
+      packageName: result.info.packageName,
+      commitSha: result.info.commitSha,
+    });
+  } else {
+    logger.warn(
+      'Vendored bindings validation failed; Soroban integration may fail at runtime',
+      {
+        vendorPath: result.info.vendorPath,
+        errors: result.errors,
+        commitSha: result.info.commitSha,
+      },
+    );
+  }
+}
+
 // Execute validation immediately
 validateEnv();
+logBindingsValidation();
 
 /**
  * Create and configure the Express app without starting any background
@@ -136,6 +134,7 @@ export function createApp(): Express {
   app.use("/api/chat", chatRoutes);
   app.use("/api/notifications", notificationsRoutes);
   app.use("/api/admin/metrics", adminMetricsRoutes);
+  app.use("/api/admin/cors-diagnostics", corsDiagnosticsRoutes);
 
   // Prometheus metrics endpoint
   app.use('/metrics', metricsRoutes);

--- a/src/routes/admin-cors-diagnostics.routes.ts
+++ b/src/routes/admin-cors-diagnostics.routes.ts
@@ -1,0 +1,101 @@
+import { Router, Request, Response } from 'express';
+import { requireAdmin } from '../middleware/auth.middleware';
+import { getHttpCorsOrigins } from '../utils/cors';
+import { getCorsOrigins as getSocketCorsOrigins } from '../socket';
+
+const router = Router();
+
+/**
+ * @openapi
+ * /admin/cors-diagnostics:
+ *   get:
+ *     summary: Resolved CORS origin allowlist for HTTP and Socket.IO
+ *     description: |
+ *       Returns the effective CORS configuration that this process is
+ *       enforcing right now, so operators can debug origin-mismatch
+ *       errors against frontends without needing shell access.
+ *       Admin only. Exposes only the resolved allowlist plus the
+ *       config-shaping env vars (`NODE_ENV`, `CLIENT_URL`,
+ *       `ALLOWED_ORIGINS`). No secrets are returned, and an optional
+ *       `?origin=` query parameter reports whether that origin would
+ *       be accepted.
+ *     tags:
+ *       - Admin
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: origin
+ *         schema:
+ *           type: string
+ *         description: An origin to test against the resolved allowlist.
+ *     responses:
+ *       200:
+ *         description: Resolved CORS configuration
+ */
+router.get('/', requireAdmin, (req: Request, res: Response) => {
+  const nodeEnv = process.env.NODE_ENV ?? 'development';
+  const clientUrl = process.env.CLIENT_URL ?? null;
+  const allowedOriginsRaw = process.env.ALLOWED_ORIGINS ?? null;
+  const allowedOrigins = allowedOriginsRaw
+    ? allowedOriginsRaw.split(',').map((o) => o.trim()).filter(Boolean)
+    : [];
+
+  let http: { allowAll: boolean; origins: string[]; error?: string };
+  try {
+    const resolved = getHttpCorsOrigins();
+    if (resolved === true) {
+      http = { allowAll: true, origins: [] };
+    } else if (Array.isArray(resolved)) {
+      http = { allowAll: false, origins: resolved };
+    } else if (typeof resolved === 'string') {
+      http = { allowAll: false, origins: [resolved] };
+    } else {
+      http = { allowAll: false, origins: [] };
+    }
+  } catch (e) {
+    http = { allowAll: false, origins: [], error: (e as Error).message };
+  }
+
+  let socket: { allowAll: boolean; origins: string[]; error?: string };
+  try {
+    const resolved = getSocketCorsOrigins();
+    if (resolved === '*') {
+      socket = { allowAll: true, origins: [] };
+    } else if (Array.isArray(resolved)) {
+      socket = { allowAll: false, origins: resolved };
+    } else {
+      socket = { allowAll: false, origins: [resolved] };
+    }
+  } catch (e) {
+    socket = { allowAll: false, origins: [], error: (e as Error).message };
+  }
+
+  const testOrigin =
+    typeof req.query.origin === 'string' ? req.query.origin : null;
+
+  const matches = (origins: string[], allowAll: boolean): boolean | null => {
+    if (testOrigin === null) return null;
+    if (allowAll) return true;
+    return origins.includes(testOrigin);
+  };
+
+  res.json({
+    env: {
+      nodeEnv,
+      clientUrl,
+      allowedOrigins,
+    },
+    http,
+    socket,
+    test: testOrigin
+      ? {
+          origin: testOrigin,
+          httpAllowed: matches(http.origins, http.allowAll),
+          socketAllowed: matches(socket.origins, socket.allowAll),
+        }
+      : null,
+  });
+});
+
+export default router;

--- a/src/routes/admin-dead-letter.routes.ts
+++ b/src/routes/admin-dead-letter.routes.ts
@@ -1,0 +1,138 @@
+/**
+ * Admin routes for the dead-letter queue (Issue #193). Lets an operator
+ * inspect and replay notification/websocket dispatches that failed at
+ * runtime, without needing shell or DB access.
+ *
+ * Gated by `requireAdmin`. All write actions return a structured summary so
+ * a CI smoke test or an on-call runbook can assert against it.
+ */
+import { Router, Request, Response } from 'express';
+import { DispatchChannel, DispatchStatus } from '@prisma/client';
+import { requireAdmin } from '../middleware/auth.middleware';
+import deadLetterQueueService, {
+  RetryHandlers,
+} from '../services/dead-letter-queue.service';
+import notificationService from '../services/notification.service';
+import websocketService from '../services/websocket.service';
+import logger from '../utils/logger';
+
+const router = Router();
+
+/**
+ * Build retry handlers that delegate back into the existing dispatchers.
+ * Lives in the route module on purpose: keeps the DLQ service free of a
+ * compile-time dependency on the dispatchers (no import cycle).
+ */
+function buildRetryHandlers(): RetryHandlers {
+  return {
+    notificationCreate: async (payload) => {
+      return notificationService.createNotificationForRetry(payload);
+    },
+    websocketEmit: ({ eventName, payload }) => {
+      websocketService.replayEmit(eventName, payload);
+    },
+  };
+}
+
+function parseStatus(raw: unknown): DispatchStatus | undefined {
+  if (typeof raw !== 'string') return undefined;
+  const upper = raw.toUpperCase();
+  return (Object.values(DispatchStatus) as string[]).includes(upper)
+    ? (upper as DispatchStatus)
+    : undefined;
+}
+
+function parseChannel(raw: unknown): DispatchChannel | undefined {
+  if (typeof raw !== 'string') return undefined;
+  const upper = raw.toUpperCase();
+  return (Object.values(DispatchChannel) as string[]).includes(upper)
+    ? (upper as DispatchChannel)
+    : undefined;
+}
+
+function parseInt32(raw: unknown, fallback: number): number {
+  const n = typeof raw === 'string' ? Number.parseInt(raw, 10) : NaN;
+  return Number.isFinite(n) ? n : fallback;
+}
+
+/**
+ * @openapi
+ * /admin/dead-letter:
+ *   get:
+ *     summary: List failed notification/event dispatches
+ *     description: |
+ *       Returns the dead-letter queue contents, newest first. Admin only.
+ *       Use `?status=` and `?channel=` to filter; defaults to all rows.
+ *     tags:
+ *       - Admin
+ *     security:
+ *       - bearerAuth: []
+ */
+router.get('/', requireAdmin, async (req: Request, res: Response) => {
+  try {
+    const { entries, total, limit, offset } = await deadLetterQueueService.list({
+      status: parseStatus(req.query.status),
+      channel: parseChannel(req.query.channel),
+      limit: parseInt32(req.query.limit, 50),
+      offset: parseInt32(req.query.offset, 0),
+    });
+    res.json({ entries, total, limit, offset });
+  } catch (err) {
+    logger.error('DLQ list failed', { error: err });
+    res.status(500).json({ error: 'Failed to list dead-letter entries' });
+  }
+});
+
+/**
+ * @openapi
+ * /admin/dead-letter/retry-all:
+ *   post:
+ *     summary: Replay every pending/retrying dispatch in the DLQ
+ *     description: Admin only. Returns a counts summary.
+ *     tags:
+ *       - Admin
+ *     security:
+ *       - bearerAuth: []
+ */
+router.post('/retry-all', requireAdmin, async (req: Request, res: Response) => {
+  try {
+    const limit = parseInt32(req.body?.limit ?? req.query?.limit, 50);
+    const result = await deadLetterQueueService.retryAll(
+      buildRetryHandlers(),
+      limit,
+    );
+    res.json(result);
+  } catch (err) {
+    logger.error('DLQ retry-all failed', { error: err });
+    res.status(500).json({ error: 'Failed to replay dead-letter entries' });
+  }
+});
+
+/**
+ * @openapi
+ * /admin/dead-letter/{id}/retry:
+ *   post:
+ *     summary: Replay a single DLQ entry
+ *     tags:
+ *       - Admin
+ *     security:
+ *       - bearerAuth: []
+ */
+router.post('/:id/retry', requireAdmin, async (req: Request, res: Response) => {
+  try {
+    const result = await deadLetterQueueService.retry(
+      req.params.id,
+      buildRetryHandlers(),
+    );
+    if (!result) {
+      res.status(404).json({ error: 'Dead-letter entry not found' });
+      return;
+    }
+    res.json(result);
+  } catch (err) {
+    logger.error('DLQ retry failed', { error: err, id: req.params.id });
+    res.status(500).json({ error: 'Failed to replay dead-letter entry' });
+  }
+});
+
+export default router;

--- a/src/services/dead-letter-queue.service.ts
+++ b/src/services/dead-letter-queue.service.ts
@@ -1,0 +1,268 @@
+/**
+ * Dead-letter queue for notification and websocket dispatch failures
+ * (Issue #193). Notifications and real-time events both have user-visible
+ * side effects, so silently dropping them on first error means a player
+ * never learns they won, or a UI never updates. This service persists the
+ * failed dispatch so an operator can inspect it, an automated retry can
+ * pick it up, or it can be replayed manually via the admin route.
+ *
+ * Kept storage-only on purpose: the existing codebase does not run a
+ * background queue (no BullMQ / Bee), so introducing one for this issue
+ * would be the wrong altitude. Replays are driven by an explicit admin
+ * call (`retry` / `retryAll`) which re-invokes the original dispatcher.
+ */
+import { DispatchChannel, DispatchStatus, Prisma } from "@prisma/client";
+import { prisma } from "../lib/prisma";
+import logger from "../utils/logger";
+
+/**
+ * Hard cap so a single pathological payload (e.g. a runaway error chain)
+ * can never blow up the DB column. The Prisma column is VARCHAR(1000).
+ */
+const MAX_ERROR_LEN = 1000;
+
+/**
+ * Default upper bound on retry attempts before a row is auto-marked
+ * `ABANDONED`. Tunable so callers (cron jobs, tests) can override.
+ */
+export const DEFAULT_MAX_ATTEMPTS = 5;
+
+export interface RecordFailureInput {
+  channel: DispatchChannel;
+  eventName?: string | null;
+  userId?: string | null;
+  payload: unknown;
+  error: unknown;
+}
+
+export interface RetryHandlers {
+  /**
+   * Replay a `NOTIFICATION_CREATE` row. Receives the original
+   * `createNotification` input that was stored as `payload`.
+   */
+  notificationCreate: (payload: any) => Promise<unknown>;
+  /**
+   * Replay a `WEBSOCKET_EMIT` row. Receives `{ eventName, userId, payload }`.
+   * Callers should map `eventName` back onto the appropriate
+   * `websocketService.emit*` method.
+   */
+  websocketEmit: (input: {
+    eventName: string | null;
+    userId: string | null;
+    payload: any;
+  }) => Promise<unknown> | unknown;
+}
+
+export interface RetryResult {
+  id: string;
+  status: DispatchStatus;
+  attempts: number;
+}
+
+export interface ListOptions {
+  status?: DispatchStatus;
+  channel?: DispatchChannel;
+  limit?: number;
+  offset?: number;
+}
+
+function truncateError(err: unknown): string {
+  const raw =
+    err instanceof Error
+      ? err.stack || err.message || String(err)
+      : typeof err === "string"
+        ? err
+        : (() => {
+            try {
+              return JSON.stringify(err);
+            } catch {
+              return String(err);
+            }
+          })();
+  return raw.length > MAX_ERROR_LEN ? raw.slice(0, MAX_ERROR_LEN) : raw;
+}
+
+class DeadLetterQueueService {
+  /**
+   * Record a dispatch failure. Never throws — a DLQ that crashes its caller
+   * defeats the whole point of a DLQ. On a DB error this only logs and
+   * returns `null` so the original call path stays unaffected.
+   */
+  async record(input: RecordFailureInput): Promise<{ id: string } | null> {
+    try {
+      const row = await prisma.failedDispatch.create({
+        data: {
+          channel: input.channel,
+          eventName: input.eventName ?? null,
+          userId: input.userId ?? null,
+          payload: (input.payload ?? {}) as Prisma.InputJsonValue,
+          attempts: 1,
+          status: DispatchStatus.PENDING,
+          lastError: truncateError(input.error),
+        },
+        select: { id: true },
+      });
+      logger.warn("Dispatch failure recorded in DLQ", {
+        id: row.id,
+        channel: input.channel,
+        eventName: input.eventName ?? null,
+        userId: input.userId ?? null,
+      });
+      return row;
+    } catch (err) {
+      logger.error("Failed to persist DLQ entry", { error: err });
+      return null;
+    }
+  }
+
+  /**
+   * Page over DLQ rows, newest first. Defaults to `PENDING` so an operator
+   * eyeballing `/api/admin/dead-letter` sees actionable rows by default.
+   */
+  async list(
+    options: ListOptions = {},
+  ): Promise<{ entries: any[]; total: number; limit: number; offset: number }> {
+    const limit = Math.min(Math.max(options.limit ?? 50, 1), 200);
+    const offset = Math.max(options.offset ?? 0, 0);
+    const where: Prisma.FailedDispatchWhereInput = {};
+    if (options.status) where.status = options.status;
+    if (options.channel) where.channel = options.channel;
+
+    const [entries, total] = await Promise.all([
+      prisma.failedDispatch.findMany({
+        where,
+        orderBy: { createdAt: "desc" },
+        skip: offset,
+        take: limit,
+      }),
+      prisma.failedDispatch.count({ where }),
+    ]);
+    return { entries, total, limit, offset };
+  }
+
+  /**
+   * Replay one DLQ row. Wrapped in try/catch: on success the row is moved
+   * to `RESOLVED`; on failure `attempts` is bumped and the row is moved to
+   * `ABANDONED` once the cap is reached. Returns the final row state.
+   */
+  async retry(
+    id: string,
+    handlers: RetryHandlers,
+    maxAttempts: number = DEFAULT_MAX_ATTEMPTS,
+  ): Promise<RetryResult | null> {
+    const row = await prisma.failedDispatch.findUnique({ where: { id } });
+    if (!row) {
+      logger.warn(`DLQ retry: entry ${id} not found`);
+      return null;
+    }
+    if (row.status === DispatchStatus.RESOLVED) {
+      // Idempotency: a replayed RESOLVED row is a no-op, not an error.
+      return { id: row.id, status: row.status, attempts: row.attempts };
+    }
+
+    try {
+      if (row.channel === DispatchChannel.NOTIFICATION_CREATE) {
+        await handlers.notificationCreate(row.payload as any);
+      } else {
+        await handlers.websocketEmit({
+          eventName: row.eventName,
+          userId: row.userId,
+          payload: row.payload as any,
+        });
+      }
+      const resolved = await prisma.failedDispatch.update({
+        where: { id },
+        data: {
+          status: DispatchStatus.RESOLVED,
+          resolvedAt: new Date(),
+          lastRetryAt: new Date(),
+          attempts: { increment: 1 },
+        },
+        select: { id: true, status: true, attempts: true },
+      });
+      logger.info(`DLQ retry succeeded`, { id, channel: row.channel });
+      return resolved;
+    } catch (err) {
+      const nextAttempts = row.attempts + 1;
+      const nextStatus =
+        nextAttempts >= maxAttempts
+          ? DispatchStatus.ABANDONED
+          : DispatchStatus.RETRYING;
+      const updated = await prisma.failedDispatch.update({
+        where: { id },
+        data: {
+          status: nextStatus,
+          attempts: nextAttempts,
+          lastRetryAt: new Date(),
+          lastError: truncateError(err),
+        },
+        select: { id: true, status: true, attempts: true },
+      });
+      logger.error(`DLQ retry failed`, {
+        id,
+        channel: row.channel,
+        attempts: nextAttempts,
+        status: nextStatus,
+      });
+      return updated;
+    }
+  }
+
+  /**
+   * Replay every `PENDING` / `RETRYING` row, capped to `limit`. Returns a
+   * count summary so the admin route can render a useful response.
+   */
+  async retryAll(
+    handlers: RetryHandlers,
+    limit: number = 50,
+    maxAttempts: number = DEFAULT_MAX_ATTEMPTS,
+  ): Promise<{
+    attempted: number;
+    resolved: number;
+    failed: number;
+    abandoned: number;
+  }> {
+    const capped = Math.min(Math.max(limit, 1), 200);
+    const rows = await prisma.failedDispatch.findMany({
+      where: {
+        status: { in: [DispatchStatus.PENDING, DispatchStatus.RETRYING] },
+      },
+      orderBy: { createdAt: "asc" },
+      take: capped,
+      select: { id: true },
+    });
+
+    let resolved = 0;
+    let failed = 0;
+    let abandoned = 0;
+    for (const r of rows) {
+      const result = await this.retry(r.id, handlers, maxAttempts);
+      if (!result) continue;
+      if (result.status === DispatchStatus.RESOLVED) resolved += 1;
+      else if (result.status === DispatchStatus.ABANDONED) {
+        abandoned += 1;
+        failed += 1;
+      } else failed += 1;
+    }
+    return { attempted: rows.length, resolved, failed, abandoned };
+  }
+
+  /**
+   * Delete `RESOLVED` rows older than `daysOld` so the table doesn't grow
+   * forever. Mirrors the cleanup pattern used by `notification.service`.
+   */
+  async cleanupResolved(daysOld: number = 7): Promise<number> {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - daysOld);
+    const result = await prisma.failedDispatch.deleteMany({
+      where: {
+        status: DispatchStatus.RESOLVED,
+        resolvedAt: { lt: cutoff },
+      },
+    });
+    return result.count;
+  }
+}
+
+export const deadLetterQueueService = new DeadLetterQueueService();
+export default deadLetterQueueService;

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -1,5 +1,7 @@
+import { DispatchChannel } from "@prisma/client";
 import { prisma } from "../lib/prisma";
 import logger from "../utils/logger";
+import deadLetterQueueService from "./dead-letter-queue.service";
 
 interface NotificationPreferences {
   win?: boolean;
@@ -97,8 +99,34 @@ class NotificationService {
       return notification;
     } catch (error) {
       logger.error("Failed to create notification:", error);
+      // Persist to the dead-letter queue so the dispatch is never silently
+      // lost. The DLQ helper swallows its own errors, so this path is safe
+      // for callers that handle the rethrow below.
+      await deadLetterQueueService.record({
+        channel: DispatchChannel.NOTIFICATION_CREATE,
+        eventName: input.type,
+        userId: input.userId,
+        payload: input,
+        error,
+      });
       throw error;
     }
+  }
+
+  /**
+   * Replay handler for the DLQ. Skips the preference check because at
+   * record time the caller already decided this notification should fire.
+   */
+  async createNotificationForRetry(input: CreateNotificationInput): Promise<any> {
+    return prisma.notification.create({
+      data: {
+        userId: input.userId,
+        type: input.type,
+        title: input.title,
+        message: input.message,
+        data: input.data || null,
+      },
+    });
   }
 
   /**

--- a/src/services/websocket.service.ts
+++ b/src/services/websocket.service.ts
@@ -1,5 +1,31 @@
 import { Server as SocketIOServer } from 'socket.io';
+import { DispatchChannel } from '@prisma/client';
 import logger from '../utils/logger';
+import deadLetterQueueService from './dead-letter-queue.service';
+
+/**
+ * Centralized event names so DLQ replay can map a stored `eventName` back
+ * onto the right emit method without string drift.
+ */
+export const WebSocketEvents = {
+  RoundStarted: 'round:started',
+  PredictionPlaced: 'prediction:placed',
+  RoundResolved: 'round:resolved',
+  PriceUpdate: 'price:update',
+  ChatMessage: 'chat:message',
+  NotificationNew: 'notification:new',
+  NotificationUnreadCount: 'notification:unread-count',
+} as const;
+
+export type WebSocketEventName =
+  (typeof WebSocketEvents)[keyof typeof WebSocketEvents];
+
+interface SafeEmitInput {
+  room: string;
+  event: WebSocketEventName;
+  payload: any;
+  userId?: string | null;
+}
 
 class WebSocketService {
   private io: SocketIOServer | null = null;
@@ -20,15 +46,67 @@ class WebSocketService {
   }
 
   /**
-   * Emit event when a new round starts
+   * Emit to a room; if the socket layer is not initialized or the underlying
+   * `emit` throws, record the dispatch in the dead-letter queue so it can be
+   * replayed (Issue #193). Never throws — emits are fire-and-forget on the
+   * caller's hot path.
    */
-  emitRoundStarted(round: any): void {
+  private safeEmit(input: SafeEmitInput): void {
     if (!this.io) {
-      logger.warn("WebSocket not initialized, cannot emit round:started");
+      logger.warn(`WebSocket not initialized, cannot emit ${input.event}`);
+      // fire-and-forget — DLQ helper swallows its own errors
+      void deadLetterQueueService.record({
+        channel: DispatchChannel.WEBSOCKET_EMIT,
+        eventName: input.event,
+        userId: input.userId ?? null,
+        payload: { room: input.room, data: input.payload },
+        error: new Error(`WebSocket not initialized when emitting ${input.event}`),
+      });
       return;
     }
 
-    this.io.to('round').emit("round:started", {
+    try {
+      this.io.to(input.room).emit(input.event, input.payload);
+    } catch (err) {
+      logger.error(`Failed to emit ${input.event}`, { error: err });
+      void deadLetterQueueService.record({
+        channel: DispatchChannel.WEBSOCKET_EMIT,
+        eventName: input.event,
+        userId: input.userId ?? null,
+        payload: { room: input.room, data: input.payload },
+        error: err,
+      });
+    }
+  }
+
+  /**
+   * Replay handler used by the DLQ. Re-emits an event using the stored
+   * payload. Throws if the socket layer is still not initialized so the
+   * DLQ records another attempt instead of falsely resolving the row.
+   */
+  replayEmit(
+    eventName: string | null,
+    payload: { room?: string; data?: any } | any,
+  ): void {
+    if (!this.io) {
+      throw new Error('WebSocket not initialized; cannot replay emit');
+    }
+    if (!eventName) {
+      throw new Error('Missing eventName for websocket replay');
+    }
+    const room = payload?.room as string | undefined;
+    const data = payload?.data;
+    if (!room) {
+      throw new Error('Missing room for websocket replay');
+    }
+    this.io.to(room).emit(eventName, data);
+  }
+
+  /**
+   * Emit event when a new round starts
+   */
+  emitRoundStarted(round: any): void {
+    const payload = {
       id: round.id,
       mode: round.mode,
       status: round.status,
@@ -36,8 +114,8 @@ class WebSocketService {
       endTime: round.endTime,
       startPrice: round.startPrice,
       priceRanges: round.priceRanges,
-    });
-
+    };
+    this.safeEmit({ room: 'round', event: WebSocketEvents.RoundStarted, payload });
     logger.info(`Emitted round:started for round ${round.id}`);
   }
 
@@ -45,19 +123,14 @@ class WebSocketService {
    * Emit event when a prediction is placed
    */
   emitPredictionPlaced(prediction: any, roundId: string): void {
-    if (!this.io) {
-      logger.warn("WebSocket not initialized, cannot emit prediction:placed");
-      return;
-    }
-
-    this.io.to('round').emit("prediction:placed", {
+    const payload = {
       roundId,
       predictionId: prediction.id,
       amount: prediction.amount,
       side: prediction.side,
       priceRange: prediction.priceRange,
-    });
-
+    };
+    this.safeEmit({ room: 'round', event: WebSocketEvents.PredictionPlaced, payload });
     logger.info(`Emitted prediction:placed for prediction ${prediction.id}`);
   }
 
@@ -65,12 +138,7 @@ class WebSocketService {
    * Emit event when a round is resolved
    */
   emitRoundResolved(round: any): void {
-    if (!this.io) {
-      logger.warn("WebSocket not initialized, cannot emit round:resolved");
-      return;
-    }
-
-    this.io.to('round').emit("round:resolved", {
+    const payload = {
       id: round.id,
       status: round.status,
       startPrice: round.startPrice,
@@ -78,8 +146,8 @@ class WebSocketService {
       resolvedAt: round.resolvedAt,
       predictions: round.predictions?.length || 0,
       winners: round.predictions?.filter((p: any) => p.won === true).length || 0,
-    });
-
+    };
+    this.safeEmit({ room: 'round', event: WebSocketEvents.RoundResolved, payload });
     logger.info(`Emitted round:resolved for round ${round.id}`);
   }
 
@@ -87,28 +155,19 @@ class WebSocketService {
    * Emit price update event
    */
   emitPriceUpdate(asset: string, price: number | string): void {
-    if (!this.io) {
-      logger.warn("WebSocket not initialized, cannot emit price:update");
-      return;
-    }
-
-    this.io.to('round').emit("price:update", {
+    const payload = {
       asset,
       price,
       timestamp: new Date().toISOString(),
-    });
+    };
+    this.safeEmit({ room: 'round', event: WebSocketEvents.PriceUpdate, payload });
   }
 
   /**
    * Emit chat message to chat room
    */
   emitChatMessage(message: any): void {
-    if (!this.io) {
-      logger.warn('WebSocket not initialized, cannot emit chat:message');
-      return;
-    }
-
-    this.io.to('chat').emit('chat:message', message);
+    this.safeEmit({ room: 'chat', event: WebSocketEvents.ChatMessage, payload: message });
     logger.info(`Emitted chat:message: ${message.id}`);
   }
 
@@ -116,12 +175,7 @@ class WebSocketService {
    * Emit a notification to a specific user
    */
   emitNotification(userId: string, notification: any): void {
-    if (!this.io) {
-      logger.warn("WebSocket not initialized, cannot emit notification");
-      return;
-    }
-
-    this.io.to(`user:${userId}`).emit("notification:new", {
+    const payload = {
       id: notification.id,
       type: notification.type,
       title: notification.title,
@@ -129,8 +183,13 @@ class WebSocketService {
       data: notification.data,
       isRead: notification.isRead,
       createdAt: notification.createdAt?.toISOString?.() || notification.createdAt,
+    };
+    this.safeEmit({
+      room: `user:${userId}`,
+      event: WebSocketEvents.NotificationNew,
+      payload,
+      userId,
     });
-
     logger.info(`Emitted notification to user ${userId}`);
   }
 
@@ -138,16 +197,16 @@ class WebSocketService {
    * Emit an unread count update to a specific user
    */
   emitUnreadCountUpdate(userId: string, unreadCount: number): void {
-    if (!this.io) {
-      logger.warn("WebSocket not initialized, cannot emit unread count update");
-      return;
-    }
-
-    this.io.to(`user:${userId}`).emit("notification:unread-count", {
+    const payload = {
       unreadCount,
       timestamp: new Date().toISOString(),
+    };
+    this.safeEmit({
+      room: `user:${userId}`,
+      event: WebSocketEvents.NotificationUnreadCount,
+      payload,
+      userId,
     });
-
     logger.info(`Emitted unread count update to user ${userId}: ${unreadCount}`);
   }
 }

--- a/src/tests/bindings-validator.spec.ts
+++ b/src/tests/bindings-validator.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * Regression coverage for #191 — vendored @tevalabs/xelma-bindings
+ * integrity check that runs at startup. The check must distinguish
+ * "completely missing", "partial install", "wrong package name", and
+ * "fully present" so operators get an actionable warning before the
+ * Soroban service throws an opaque module-resolution error.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+import { validateVendoredBindings } from "../utils/bindings-validator";
+
+let cwdRoot = "";
+
+function makeVendor(
+  layout: {
+    esm?: boolean;
+    cjs?: boolean;
+    pkg?: { name?: string } | null;
+    commitSha?: string;
+  } = {},
+): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "xelma-vendor-"));
+  const vendor = path.join(root, "vendor", "xelma-bindings");
+  fs.mkdirSync(path.join(vendor, "dist", "cjs"), { recursive: true });
+
+  if (layout.esm) {
+    fs.writeFileSync(path.join(vendor, "dist", "index.js"), "// esm");
+  }
+  if (layout.cjs) {
+    fs.writeFileSync(path.join(vendor, "dist", "cjs", "index.js"), "// cjs");
+  }
+  if (layout.pkg !== null) {
+    const pkg = layout.pkg ?? { name: "@tevalabs/xelma-bindings" };
+    fs.writeFileSync(
+      path.join(vendor, "package.json"),
+      JSON.stringify(pkg, null, 2),
+    );
+  }
+  if (layout.commitSha) {
+    fs.writeFileSync(path.join(vendor, ".commit-sha"), layout.commitSha);
+  }
+  return root;
+}
+
+describe("validateVendoredBindings", () => {
+  beforeEach(() => {
+    cwdRoot = "";
+  });
+
+  afterEach(() => {
+    if (cwdRoot && fs.existsSync(cwdRoot)) {
+      fs.rmSync(cwdRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("reports missing vendor directory entirely", () => {
+    cwdRoot = fs.mkdtempSync(path.join(os.tmpdir(), "no-vendor-"));
+    const result = validateVendoredBindings(cwdRoot);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toContain("vendor/xelma-bindings missing");
+    expect(result.info.commitSha).toBeNull();
+  });
+
+  it("reports missing ESM entry when only CJS is present", () => {
+    cwdRoot = makeVendor({ esm: false, cjs: true });
+    const result = validateVendoredBindings(cwdRoot);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes("ESM entry missing"))).toBe(true);
+  });
+
+  it("reports missing CJS entry when only ESM is present", () => {
+    cwdRoot = makeVendor({ esm: true, cjs: false });
+    const result = validateVendoredBindings(cwdRoot);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes("CJS entry missing"))).toBe(true);
+  });
+
+  it("reports wrong package name", () => {
+    cwdRoot = makeVendor({ esm: true, cjs: true, pkg: { name: "wrong-name" } });
+    const result = validateVendoredBindings(cwdRoot);
+    expect(result.ok).toBe(false);
+    expect(
+      result.errors.some((e) => e.includes("@tevalabs/xelma-bindings")),
+    ).toBe(true);
+  });
+
+  it("returns ok=true when ESM + CJS + correct package.json present", () => {
+    cwdRoot = makeVendor({
+      esm: true,
+      cjs: true,
+      pkg: { name: "@tevalabs/xelma-bindings" },
+      commitSha: "abc123def456\n",
+    });
+    const result = validateVendoredBindings(cwdRoot);
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.info.packageName).toBe("@tevalabs/xelma-bindings");
+    expect(result.info.commitSha).toBe("abc123def456");
+  });
+
+  it("treats a missing .commit-sha as non-fatal (commitSha null)", () => {
+    cwdRoot = makeVendor({ esm: true, cjs: true });
+    const result = validateVendoredBindings(cwdRoot);
+    expect(result.ok).toBe(true);
+    expect(result.info.commitSha).toBeNull();
+  });
+});

--- a/src/tests/dead-letter-queue.spec.ts
+++ b/src/tests/dead-letter-queue.spec.ts
@@ -1,0 +1,289 @@
+/**
+ * Regression coverage for Issue #193 — dead-letter queue for failed
+ * notification and websocket dispatches. Verifies the contract that
+ * matters: a failure is persisted, attempts are tracked, retries flip
+ * the row to RESOLVED or ABANDONED at the right boundary, and a record()
+ * call that itself fails NEVER throws back into the dispatcher.
+ */
+import { describe, it, expect, beforeEach } from '@jest/globals';
+
+// Typed loosely on purpose: the global `jest.fn()` returns a generic mock
+// that infers `never` for `mockResolvedValue` under `strict: true`. Casting
+// here keeps the existing repo style (no per-call generics) while staying
+// safe under tsc --noEmit.
+const mockCreate: any = jest.fn();
+const mockFindUnique: any = jest.fn();
+const mockFindMany: any = jest.fn();
+const mockCount: any = jest.fn();
+const mockUpdate: any = jest.fn();
+const mockDeleteMany: any = jest.fn();
+
+jest.mock('../lib/prisma', () => ({
+  prisma: {
+    failedDispatch: {
+      create: (...args: any[]) => mockCreate(...args),
+      findUnique: (...args: any[]) => mockFindUnique(...args),
+      findMany: (...args: any[]) => mockFindMany(...args),
+      count: (...args: any[]) => mockCount(...args),
+      update: (...args: any[]) => mockUpdate(...args),
+      deleteMany: (...args: any[]) => mockDeleteMany(...args),
+    },
+  },
+}));
+
+jest.mock('../utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+// Stand-in enum values so the test does not require the generated Prisma
+// client to be available in CI before `prisma generate` runs.
+jest.mock('@prisma/client', () => ({
+  DispatchChannel: {
+    NOTIFICATION_CREATE: 'NOTIFICATION_CREATE',
+    WEBSOCKET_EMIT: 'WEBSOCKET_EMIT',
+  },
+  DispatchStatus: {
+    PENDING: 'PENDING',
+    RETRYING: 'RETRYING',
+    RESOLVED: 'RESOLVED',
+    ABANDONED: 'ABANDONED',
+  },
+  Prisma: {},
+}));
+
+import deadLetterQueueService from '../services/dead-letter-queue.service';
+import { DispatchChannel, DispatchStatus } from '@prisma/client';
+
+describe('DeadLetterQueueService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('record', () => {
+    it('persists a failure with truncated error and PENDING status', async () => {
+      mockCreate.mockResolvedValue({ id: 'dlq-1' });
+      const longErr = new Error('x'.repeat(2_500));
+
+      const result = await deadLetterQueueService.record({
+        channel: DispatchChannel.NOTIFICATION_CREATE,
+        eventName: 'WIN',
+        userId: 'user-1',
+        payload: { foo: 'bar' },
+        error: longErr,
+      });
+
+      expect(result).toEqual({ id: 'dlq-1' });
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      const args: any = mockCreate.mock.calls[0][0];
+      expect(args.data.channel).toBe('NOTIFICATION_CREATE');
+      expect(args.data.eventName).toBe('WIN');
+      expect(args.data.userId).toBe('user-1');
+      expect(args.data.attempts).toBe(1);
+      expect(args.data.status).toBe('PENDING');
+      expect(args.data.lastError.length).toBeLessThanOrEqual(1000);
+    });
+
+    it('swallows DB errors and returns null so the caller is never crashed by the DLQ', async () => {
+      mockCreate.mockRejectedValue(new Error('db down'));
+
+      const result = await deadLetterQueueService.record({
+        channel: DispatchChannel.WEBSOCKET_EMIT,
+        eventName: 'notification:new',
+        payload: {},
+        error: new Error('original'),
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('serializes non-Error errors safely', async () => {
+      mockCreate.mockResolvedValue({ id: 'dlq-2' });
+      await deadLetterQueueService.record({
+        channel: DispatchChannel.WEBSOCKET_EMIT,
+        payload: {},
+        error: { code: 42, msg: 'something broke' },
+      });
+      const args: any = mockCreate.mock.calls[0][0];
+      expect(typeof args.data.lastError).toBe('string');
+      expect(args.data.lastError).toContain('42');
+    });
+  });
+
+  describe('retry', () => {
+    const handlers = {
+      notificationCreate: jest.fn(),
+      websocketEmit: jest.fn(),
+    } as any;
+
+    beforeEach(() => {
+      handlers.notificationCreate.mockReset();
+      handlers.websocketEmit.mockReset();
+    });
+
+    it('returns null for an unknown id', async () => {
+      mockFindUnique.mockResolvedValue(null);
+      const result = await deadLetterQueueService.retry('nope', handlers);
+      expect(result).toBeNull();
+      expect(handlers.notificationCreate).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent on a RESOLVED row', async () => {
+      mockFindUnique.mockResolvedValue({
+        id: 'r1',
+        status: 'RESOLVED',
+        channel: 'NOTIFICATION_CREATE',
+        attempts: 2,
+        payload: {},
+      });
+      const result = await deadLetterQueueService.retry('r1', handlers);
+      expect(result).toEqual({ id: 'r1', status: 'RESOLVED', attempts: 2 });
+      expect(handlers.notificationCreate).not.toHaveBeenCalled();
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('marks RESOLVED when the handler succeeds', async () => {
+      mockFindUnique.mockResolvedValue({
+        id: 'r2',
+        status: 'PENDING',
+        channel: 'NOTIFICATION_CREATE',
+        attempts: 1,
+        payload: { userId: 'u1', type: 'WIN', title: 't', message: 'm' },
+        eventName: 'WIN',
+        userId: 'u1',
+      });
+      handlers.notificationCreate.mockResolvedValue({ id: 'notif-x' });
+      mockUpdate.mockResolvedValue({ id: 'r2', status: 'RESOLVED', attempts: 2 });
+
+      const result = await deadLetterQueueService.retry('r2', handlers);
+
+      expect(handlers.notificationCreate).toHaveBeenCalledWith({
+        userId: 'u1',
+        type: 'WIN',
+        title: 't',
+        message: 'm',
+      });
+      expect(result?.status).toBe('RESOLVED');
+      const updateArgs: any = mockUpdate.mock.calls[0][0];
+      expect(updateArgs.data.status).toBe('RESOLVED');
+      expect(updateArgs.data.resolvedAt).toBeInstanceOf(Date);
+    });
+
+    it('bumps attempts to RETRYING below the cap when the handler fails', async () => {
+      mockFindUnique.mockResolvedValue({
+        id: 'r3',
+        status: 'PENDING',
+        channel: 'WEBSOCKET_EMIT',
+        attempts: 1,
+        payload: { room: 'user:u1', data: {} },
+        eventName: 'notification:new',
+        userId: 'u1',
+      });
+      handlers.websocketEmit.mockImplementation(() => {
+        throw new Error('socket still down');
+      });
+      mockUpdate.mockResolvedValue({ id: 'r3', status: 'RETRYING', attempts: 2 });
+
+      const result = await deadLetterQueueService.retry('r3', handlers, 5);
+
+      expect(result?.status).toBe('RETRYING');
+      const updateArgs: any = mockUpdate.mock.calls[0][0];
+      expect(updateArgs.data.status).toBe('RETRYING');
+      expect(updateArgs.data.attempts).toBe(2);
+      expect(updateArgs.data.lastError).toContain('socket still down');
+    });
+
+    it('marks ABANDONED once attempts reach the cap', async () => {
+      mockFindUnique.mockResolvedValue({
+        id: 'r4',
+        status: 'RETRYING',
+        channel: 'WEBSOCKET_EMIT',
+        attempts: 4, // next attempt -> 5, hits cap of 5
+        payload: { room: 'user:u1', data: {} },
+        eventName: 'notification:new',
+        userId: 'u1',
+      });
+      handlers.websocketEmit.mockImplementation(() => {
+        throw new Error('still failing');
+      });
+      mockUpdate.mockResolvedValue({ id: 'r4', status: 'ABANDONED', attempts: 5 });
+
+      const result = await deadLetterQueueService.retry('r4', handlers, 5);
+
+      expect(result?.status).toBe('ABANDONED');
+      const updateArgs: any = mockUpdate.mock.calls[0][0];
+      expect(updateArgs.data.status).toBe('ABANDONED');
+      expect(updateArgs.data.attempts).toBe(5);
+    });
+  });
+
+  describe('retryAll', () => {
+    it('returns a counts summary across mixed outcomes', async () => {
+      const handlers = {
+        notificationCreate: jest.fn(),
+        websocketEmit: jest.fn(),
+      } as any;
+      mockFindMany.mockResolvedValue([{ id: 'a' }, { id: 'b' }]);
+      // First retry call: success
+      mockFindUnique
+        .mockResolvedValueOnce({
+          id: 'a',
+          status: 'PENDING',
+          channel: 'NOTIFICATION_CREATE',
+          attempts: 1,
+          payload: {},
+        })
+        .mockResolvedValueOnce({
+          id: 'b',
+          status: 'RETRYING',
+          channel: 'NOTIFICATION_CREATE',
+          attempts: 4,
+          payload: {},
+        });
+      handlers.notificationCreate
+        .mockResolvedValueOnce({ id: 'notif' })
+        .mockRejectedValueOnce(new Error('boom'));
+      mockUpdate
+        .mockResolvedValueOnce({ id: 'a', status: 'RESOLVED', attempts: 2 })
+        .mockResolvedValueOnce({ id: 'b', status: 'ABANDONED', attempts: 5 });
+
+      const result = await deadLetterQueueService.retryAll(handlers, 50, 5);
+
+      expect(result).toEqual({
+        attempted: 2,
+        resolved: 1,
+        failed: 1,
+        abandoned: 1,
+      });
+    });
+  });
+
+  describe('list', () => {
+    it('clamps limit to the [1, 200] range', async () => {
+      mockFindMany.mockResolvedValue([]);
+      mockCount.mockResolvedValue(0);
+
+      await deadLetterQueueService.list({ limit: 9999 });
+      expect(mockFindMany.mock.calls[0][0].take).toBe(200);
+
+      await deadLetterQueueService.list({ limit: -3 });
+      expect(mockFindMany.mock.calls[1][0].take).toBe(1);
+    });
+  });
+
+  describe('cleanupResolved', () => {
+    it('only deletes RESOLVED rows older than the cutoff', async () => {
+      mockDeleteMany.mockResolvedValue({ count: 7 });
+      const count = await deadLetterQueueService.cleanupResolved(3);
+      expect(count).toBe(7);
+      const args: any = mockDeleteMany.mock.calls[0][0];
+      expect(args.where.status).toBe('RESOLVED');
+      expect(args.where.resolvedAt.lt).toBeInstanceOf(Date);
+    });
+  });
+});

--- a/src/tests/http-cors.spec.ts
+++ b/src/tests/http-cors.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression coverage for #192 — the resolved HTTP CORS allowlist that
+ * /api/admin/cors-diagnostics returns to operators. The diagnostics
+ * endpoint is a thin wrapper over getHttpCorsOrigins(), so locking the
+ * resolver's behavior here pins what operators will see.
+ *
+ * Mirrors the pattern in socket-cors.spec.ts.
+ */
+import { describe, it, expect, afterEach } from "@jest/globals";
+
+const originalEnv = process.env;
+
+function setEnv(overrides: Record<string, string | undefined>): void {
+  process.env = { ...originalEnv, ...overrides };
+}
+
+function restoreEnv(): void {
+  process.env = originalEnv;
+}
+
+describe("getHttpCorsOrigins", () => {
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it("throws in production when CLIENT_URL is not set", () => {
+    setEnv({
+      NODE_ENV: "production",
+      CLIENT_URL: undefined,
+      ALLOWED_ORIGINS: undefined,
+    });
+    jest.resetModules();
+    const { getHttpCorsOrigins } = require("../utils/cors");
+    expect(() => getHttpCorsOrigins()).toThrow(
+      /CLIENT_URL environment variable is required in production/,
+    );
+  });
+
+  it("returns CLIENT_URL alone in production", () => {
+    setEnv({
+      NODE_ENV: "production",
+      CLIENT_URL: "https://app.example.com",
+      ALLOWED_ORIGINS: undefined,
+    });
+    jest.resetModules();
+    const { getHttpCorsOrigins } = require("../utils/cors");
+    expect(getHttpCorsOrigins()).toBe("https://app.example.com");
+  });
+
+  it("merges ALLOWED_ORIGINS in production", () => {
+    setEnv({
+      NODE_ENV: "production",
+      CLIENT_URL: "https://app.example.com",
+      ALLOWED_ORIGINS: "https://staging.example.com,https://dev.example.com",
+    });
+    jest.resetModules();
+    const { getHttpCorsOrigins } = require("../utils/cors");
+    expect(getHttpCorsOrigins()).toEqual([
+      "https://app.example.com",
+      "https://staging.example.com",
+      "https://dev.example.com",
+    ]);
+  });
+
+  it("returns true (allow-all) in development when CLIENT_URL unset", () => {
+    setEnv({
+      NODE_ENV: "development",
+      CLIENT_URL: undefined,
+      ALLOWED_ORIGINS: undefined,
+    });
+    jest.resetModules();
+    const { getHttpCorsOrigins } = require("../utils/cors");
+    expect(getHttpCorsOrigins()).toBe(true);
+  });
+
+  it("filters blank tokens out of ALLOWED_ORIGINS", () => {
+    setEnv({
+      NODE_ENV: "production",
+      CLIENT_URL: "https://app.example.com",
+      ALLOWED_ORIGINS: "https://a.example.com,,  ,https://b.example.com",
+    });
+    jest.resetModules();
+    const { getHttpCorsOrigins } = require("../utils/cors");
+    expect(getHttpCorsOrigins()).toEqual([
+      "https://app.example.com",
+      "https://a.example.com",
+      "https://b.example.com",
+    ]);
+  });
+});

--- a/src/tests/websocket-dlq.spec.ts
+++ b/src/tests/websocket-dlq.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * Regression coverage for Issue #193 — websocket emit failures route into
+ * the DLQ instead of disappearing into a log line. Two cases matter most:
+ *
+ *   1. The socket layer was never initialized (process started API-only,
+ *      or socket init crashed). Old behavior: warn + drop. New behavior:
+ *      DLQ row recorded so the event can be replayed once sockets are up.
+ *   2. The underlying `io.to(room).emit(...)` throws. Old behavior:
+ *      uncaught and could break a hot path (e.g. round resolution).
+ *      New behavior: caught + DLQ row recorded.
+ */
+import { describe, it, expect, beforeEach } from '@jest/globals';
+
+const mockRecord: any = jest.fn();
+
+jest.mock('../services/dead-letter-queue.service', () => ({
+  __esModule: true,
+  default: { record: (...args: any[]) => mockRecord(...args) },
+}));
+
+jest.mock('../utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock('@prisma/client', () => ({
+  DispatchChannel: {
+    NOTIFICATION_CREATE: 'NOTIFICATION_CREATE',
+    WEBSOCKET_EMIT: 'WEBSOCKET_EMIT',
+  },
+}));
+
+import websocketService from '../services/websocket.service';
+
+describe('WebSocketService DLQ wiring (#193)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Force the singleton back to an uninitialized state between tests.
+    (websocketService as any).io = null;
+  });
+
+  it('records a DLQ entry when emitNotification fires before init', () => {
+    websocketService.emitNotification('user-1', {
+      id: 'n1',
+      type: 'WIN',
+      title: 't',
+      message: 'm',
+      data: null,
+      isRead: false,
+      createdAt: new Date('2026-05-30T00:00:00Z'),
+    });
+
+    expect(mockRecord).toHaveBeenCalledTimes(1);
+    const args: any = mockRecord.mock.calls[0][0];
+    expect(args.channel).toBe('WEBSOCKET_EMIT');
+    expect(args.eventName).toBe('notification:new');
+    expect(args.userId).toBe('user-1');
+    expect(args.payload.room).toBe('user:user-1');
+    expect(args.payload.data.id).toBe('n1');
+  });
+
+  it('records a DLQ entry when emitChatMessage fires before init', () => {
+    websocketService.emitChatMessage({ id: 'm1', content: 'hi' });
+    expect(mockRecord).toHaveBeenCalledTimes(1);
+    expect(mockRecord.mock.calls[0][0].eventName).toBe('chat:message');
+    expect(mockRecord.mock.calls[0][0].userId).toBeNull();
+  });
+
+  it('records a DLQ entry when the underlying emit throws', () => {
+    const emit = jest.fn(() => {
+      throw new Error('socket crash');
+    });
+    const fakeIo = { to: jest.fn(() => ({ emit })) } as any;
+    websocketService.initialize(fakeIo);
+
+    websocketService.emitRoundStarted({
+      id: 'r1',
+      mode: 'UP_DOWN',
+      status: 'ACTIVE',
+      startTime: new Date(),
+      endTime: new Date(),
+      startPrice: '1.00',
+      priceRanges: null,
+    });
+
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(mockRecord).toHaveBeenCalledTimes(1);
+    const args: any = mockRecord.mock.calls[0][0];
+    expect(args.channel).toBe('WEBSOCKET_EMIT');
+    expect(args.eventName).toBe('round:started');
+    expect(args.payload.room).toBe('round');
+    expect(args.error).toBeInstanceOf(Error);
+  });
+
+  it('does not record when emit succeeds', () => {
+    const emit = jest.fn();
+    const fakeIo = { to: jest.fn(() => ({ emit })) } as any;
+    websocketService.initialize(fakeIo);
+
+    websocketService.emitPriceUpdate('XLM', '0.42');
+
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(mockRecord).not.toHaveBeenCalled();
+  });
+
+  it('replayEmit throws if sockets are not initialized so DLQ retry bumps attempts', () => {
+    (websocketService as any).io = null;
+    expect(() => websocketService.replayEmit('notification:new', { room: 'user:u1', data: {} })).toThrow();
+  });
+
+  it('replayEmit re-emits on the right room when initialized', () => {
+    const emit = jest.fn();
+    const fakeIo = { to: jest.fn(() => ({ emit })) } as any;
+    websocketService.initialize(fakeIo);
+    websocketService.replayEmit('notification:new', { room: 'user:u1', data: { id: 'x' } });
+    expect(fakeIo.to).toHaveBeenCalledWith('user:u1');
+    expect(emit).toHaveBeenCalledWith('notification:new', { id: 'x' });
+  });
+});

--- a/src/utils/bindings-validator.ts
+++ b/src/utils/bindings-validator.ts
@@ -1,0 +1,92 @@
+import fs from "fs";
+import path from "path";
+
+export interface BindingsValidationResult {
+  ok: boolean;
+  errors: string[];
+  info: {
+    vendorPath: string;
+    esmEntry: string | null;
+    cjsEntry: string | null;
+    packageName: string | null;
+    commitSha: string | null;
+  };
+}
+
+const BINDINGS_PACKAGE_NAME = "@tevalabs/xelma-bindings";
+
+export function getVendorBindingsRoot(cwd: string = process.cwd()): string {
+  return path.resolve(cwd, "vendor", "xelma-bindings");
+}
+
+/**
+ * Verify that the vendored @tevalabs/xelma-bindings package is present and
+ * well-formed. install-bindings.js writes ESM + CJS dist outputs and a
+ * .commit-sha marker file; this check confirms each artifact exists and
+ * surfaces the recorded upstream SHA so operators can spot a stale vendor.
+ *
+ * Returns a structured result rather than throwing — startup callers decide
+ * whether a missing vendor is fatal (Soroban-required deployments) or just
+ * worth logging (API-only deployments).
+ */
+export function validateVendoredBindings(
+  cwd: string = process.cwd(),
+): BindingsValidationResult {
+  const vendorPath = getVendorBindingsRoot(cwd);
+  const esmEntryPath = path.join(vendorPath, "dist", "index.js");
+  const cjsEntryPath = path.join(vendorPath, "dist", "cjs", "index.js");
+  const packageJsonPath = path.join(vendorPath, "package.json");
+  const commitShaPath = path.join(vendorPath, ".commit-sha");
+
+  const errors: string[] = [];
+  let packageName: string | null = null;
+  let commitSha: string | null = null;
+
+  if (!fs.existsSync(vendorPath)) {
+    errors.push(
+      `vendor/xelma-bindings missing at ${vendorPath}. ` +
+        "Run `npm run install-bindings` to fetch and build the bindings.",
+    );
+  } else {
+    if (!fs.existsSync(esmEntryPath)) {
+      errors.push(`ESM entry missing: ${esmEntryPath}`);
+    }
+    if (!fs.existsSync(cjsEntryPath)) {
+      errors.push(`CJS entry missing: ${cjsEntryPath}`);
+    }
+    if (!fs.existsSync(packageJsonPath)) {
+      errors.push(`package.json missing: ${packageJsonPath}`);
+    } else {
+      try {
+        const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+        packageName = typeof pkg?.name === "string" ? pkg.name : null;
+        if (packageName !== BINDINGS_PACKAGE_NAME) {
+          errors.push(
+            `vendor package.json name is ${JSON.stringify(packageName)}, expected ${BINDINGS_PACKAGE_NAME}`,
+          );
+        }
+      } catch (e) {
+        errors.push(`vendor package.json is not valid JSON: ${(e as Error).message}`);
+      }
+    }
+    if (fs.existsSync(commitShaPath)) {
+      try {
+        commitSha = fs.readFileSync(commitShaPath, "utf8").trim() || null;
+      } catch {
+        commitSha = null;
+      }
+    }
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    info: {
+      vendorPath,
+      esmEntry: fs.existsSync(esmEntryPath) ? esmEntryPath : null,
+      cjsEntry: fs.existsSync(cjsEntryPath) ? cjsEntryPath : null,
+      packageName,
+      commitSha,
+    },
+  };
+}

--- a/src/utils/cors.ts
+++ b/src/utils/cors.ts
@@ -1,0 +1,33 @@
+/**
+ * Resolve the CORS origin allowlist for Express HTTP routes.
+ * Mirrors the logic in socket.ts getCorsOrigins() so both layers
+ * enforce the same policy.
+ */
+export function getHttpCorsOrigins(): string | string[] | boolean {
+  const clientUrl = process.env.CLIENT_URL;
+  const isProduction = process.env.NODE_ENV === 'production';
+
+  if (isProduction) {
+    if (!clientUrl) {
+      throw new Error(
+        'CLIENT_URL environment variable is required in production. ' +
+          'HTTP CORS cannot use wildcard origin (*) in production.',
+      );
+    }
+    const additional = process.env.ALLOWED_ORIGINS;
+    if (additional) {
+      return [clientUrl, ...additional.split(',').map((o) => o.trim()).filter(Boolean)];
+    }
+    return clientUrl;
+  }
+
+  if (!clientUrl) {
+    return true; // Allow all origins in development when CLIENT_URL is unset
+  }
+
+  const additional = process.env.ALLOWED_ORIGINS;
+  if (additional) {
+    return [clientUrl, ...additional.split(',').map((o) => o.trim()).filter(Boolean)];
+  }
+  return clientUrl;
+}


### PR DESCRIPTION
## Summary

Bundles four runtime/debugging/reliability improvements aimed at making the deploy-vs-local gap smaller, on-call faster, and dispatched events durable. Adds a Render-parity local profile, a startup integrity check for the vendored Soroban bindings, an admin-only CORS diagnostics endpoint, and a dead-letter queue for failed notification/event dispatches.

closes #190
closes #191
closes #192
closes #193

## Changes

- **#190 — Render-parity local profile and startup docs**:
  - `package.json`: new `npm run start:render-parity` script (`NODE_ENV=production node dist/index.js`) so contributors hit the same code paths Render does — strict CORS, production logging, no dev fallbacks.
  - `README.md`: new "Render Parity Local Profile" section with a runnable example and a table of the env vars Render supplies (CLIENT_URL, JWT_SECRET, DATABASE_URL, optional SOROBAN_*). Includes a pointer to the new `/api/admin/cors-diagnostics` for debugging origin mismatches.
  - `.env.example`: short pointer to the README section in the server-config block.

- **#191 — Validate vendored bindings integrity during startup**:
  - `src/utils/bindings-validator.ts` (new): `validateVendoredBindings()` checks that `vendor/xelma-bindings/dist/index.js`, `dist/cjs/index.js`, and `package.json` (with the right `name`) all exist. Reads `.commit-sha` and returns it in the structured result so a stale vendor is visible at startup. Returns errors rather than throwing — API-only deployments without Soroban can still boot.
  - `scripts/install-bindings.js`: after the sparse-clone + ESM/CJS build, captures the resolved upstream commit SHA (`git rev-parse HEAD` against the temp clone) and writes it to `vendor/xelma-bindings/.commit-sha`.
  - `src/index.ts`: new `logBindingsValidation()` runs immediately after `validateEnv()` and logs the result (info on success including the recorded SHA; warn on failure with the specific errors).
  - `src/tests/bindings-validator.spec.ts` (6 cases): missing vendor entirely, partial ESM-only / CJS-only, wrong package name, fully-present happy path, and `.commit-sha`-absent treated as non-fatal.

- **#192 — Safe CORS diagnostics endpoint for operators**:
  - `src/utils/cors.ts` (new): extracts `getHttpCorsOrigins()` out of `src/index.ts` so the diagnostics route can import it without a circular import. `src/index.ts` re-exports it for backward compatibility.
  - `src/routes/admin-cors-diagnostics.routes.ts` (new): `GET /api/admin/cors-diagnostics`, gated by the existing `requireAdmin` middleware. Returns the resolved HTTP allowlist (via `getHttpCorsOrigins`), the resolved Socket.IO allowlist (via the existing `getCorsOrigins` from `src/socket.ts`), and the shaping env vars (`NODE_ENV`, `CLIENT_URL`, `ALLOWED_ORIGINS`). An optional `?origin=` query param reports whether that specific origin would be accepted by each layer. No secrets in the response.
  - `src/index.ts`: mounts the route under `/api/admin/cors-diagnostics`.
  - `src/tests/http-cors.spec.ts` (5 cases): mirrors the existing `socket-cors.spec.ts` pattern — production missing `CLIENT_URL` throws, `ALLOWED_ORIGINS` merging, dev wildcard, blank-token filtering.

- **#193 — Dead-letter flow for failed notification/event dispatch**:
  - `prisma/schema.prisma` + new migration `20260530000000_add_failed_dispatch_dlq`: adds `FailedDispatch` model with `channel` (`NOTIFICATION_CREATE` / `WEBSOCKET_EMIT`), `eventName`, `userId`, `payload`, `attempts`, `status` (`PENDING` / `RETRYING` / `RESOLVED` / `ABANDONED`), `lastError`, `lastRetryAt`, `resolvedAt`, and supporting indexes on `channel`, `status`, `createdAt`, `userId`.
  - `src/services/dead-letter-queue.service.ts` (new): `record()` persists a failure (with error truncation to fit `VARCHAR(1000)`) and is itself crash-safe — a DLQ-side failure logs but never throws into the dispatcher. `retry()` replays one row through caller-supplied handlers, flips to `RESOLVED` on success, bumps `attempts` and moves to `ABANDONED` once the cap (default 5) is reached. `retryAll()` walks the pending/retrying rows oldest-first and returns a counts summary. `cleanupResolved()` purges old resolved rows.
  - `src/services/notification.service.ts`: the `createNotification` catch path now records the failure to the DLQ before rethrowing, so the original error semantics are preserved while no notification is silently dropped. Adds `createNotificationForRetry()` for replay (skips the preference check because the original call already passed it).
  - `src/services/websocket.service.ts`: refactors every `emit*` method to go through a single `safeEmit()` helper that records to the DLQ both when the socket layer is not yet initialized AND when the underlying `io.to(room).emit(...)` throws. Adds `replayEmit()` used by the DLQ to re-emit using the stored room/event/payload. Centralized event-name constants prevent string drift between the emitter and the replayer.
  - `src/routes/admin-dead-letter.routes.ts` (new): three admin-only endpoints — `GET /api/admin/dead-letter` (list with `status`/`channel`/`limit`/`offset` filters), `POST /api/admin/dead-letter/:id/retry` (replay one), `POST /api/admin/dead-letter/retry-all` (replay all pending/retrying, counts summary). Gated by the existing `requireAdmin` middleware.
  - `src/index.ts`: mounts the route under `/api/admin/dead-letter`.
  - `src/tests/dead-letter-queue.spec.ts` (10 cases) + `src/tests/websocket-dlq.spec.ts` (6 cases): cover error truncation, DLQ-record swallowing its own DB failure, idempotent retry of `RESOLVED` rows, the `RETRYING` → `ABANDONED` cap, `retryAll` counts across mixed outcomes, list-bound clamping, cleanup-by-cutoff, and the websocket safeEmit paths (un-initialized + emit-throws + happy path).
  - `README.md`: new "Dead-letter queue for failed notifications and events" section documenting the behavior and the admin endpoints.

## Test plan

- `npm run lint` — passes (`tsc --noEmit` clean after `npx prisma generate`).
- `npm run build` — passes.
- `npx jest src/tests/bindings-validator.spec.ts src/tests/http-cors.spec.ts src/tests/socket-cors.spec.ts src/tests/dead-letter-queue.spec.ts src/tests/websocket-dlq.spec.ts src/tests/notifications.routes.spec.ts` — all green locally (existing notifications + cors suites kept green to confirm the websocket refactor and DLQ wiring did not regress).
- `npm run start:render-parity` — verified it errors fast with the expected "CLIENT_URL required in production" message when env vars are missing, and boots cleanly with them set.

## Risk notes

- Backward compatible: `getHttpCorsOrigins` is re-exported from `src/index.ts`, so any external code path still finds it at the old path.
- Bindings validator is **non-fatal** — it logs at warn level but never throws, so a deployment that intentionally skips bindings still boots.
- New admin routes (`/api/admin/cors-diagnostics`, `/api/admin/dead-letter`) are gated by the same `requireAdmin` middleware as `/api/admin/metrics`, so the auth surface is unchanged.
- DLQ recorder swallows its own errors — a DB outage that affects `FailedDispatch` cannot crash a notification or websocket dispatcher.
- DLQ migration is additive only (new enums, new table, new indexes); no existing column is touched, no data is migrated.
- No new runtime dependencies.
