### PR TITLE
feat(dx,ci): unified error code catalog + production-readiness scorecard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,24 @@ jobs:
       - name: Run lint
         run: npm run lint
 
+  scorecard:
+    name: production-readiness scorecard
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      # No `npm ci`: the scorecard intentionally has zero runtime deps so it
+      # works on fresh forks and runs in seconds.
+      - name: Run production-readiness scorecard
+        run: npm run scorecard
+
   build:
     name: build
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -803,6 +803,55 @@ Current test coverage includes:
 | `npm run prisma:migrate` | Run database migrations |
 | `npm run docs:openapi` | Generate OpenAPI JSON spec |
 | `npm run docs:postman` | Export Postman collection |
+| `npm run scorecard` | Run the production-readiness scorecard (see [#197](https://github.com/TevaLabs/Xelma-Backend/issues/197)) |
+
+---
+
+## Error Code Catalog (#196)
+
+Every error response from the API carries a stable machine-readable
+`code` (in addition to the HTTP status) so clients can branch on the
+specific failure without parsing prose. The canonical list lives in
+[`src/utils/errors.ts`](src/utils/errors.ts) as `ERROR_CATALOG` and is
+also exposed as JSON at `GET /api/errors` for client codegen.
+
+A drift test (`src/tests/error-catalog.spec.ts`) pins the catalog to
+the `ErrorCode` enum, so adding a new code without a catalog entry
+fails CI.
+
+| HTTP | Code | Description |
+|------|------|-------------|
+| 400 | `VALIDATION_ERROR` | Body / query / params failed schema validation. See `error.details`. |
+| 401 | `AUTHENTICATION_ERROR` | Missing / invalid credentials. Re-authenticate. |
+| 401 | `INVALID_CHALLENGE` | Signed challenge does not match a known issued challenge. |
+| 401 | `CHALLENGE_EXPIRED` | Challenge TTL elapsed. Request a new one. |
+| 401 | `CHALLENGE_USED` | Challenge already consumed (one-shot). |
+| 401 | `INVALID_SIGNATURE` | Signature does not verify against wallet + challenge. |
+| 403 | `AUTHORIZATION_ERROR` | Authenticated, not permitted. |
+| 404 | `NOT_FOUND` | Resource does not exist. |
+| 409 | `CONFLICT` | Generic state conflict. |
+| 409 | `ROUND_ALREADY_RESOLVED` | Round outcome already final. |
+| 409 | `DUPLICATE_PREDICTION` | User already predicted on this round. |
+| 409 | `ACTIVE_ROUND_EXISTS` | A round of the requested mode is already active. |
+| 422 | `BUSINESS_RULE_VIOLATION` | Generic domain rule violation. |
+| 422 | `INSUFFICIENT_FUNDS` | Not enough balance. |
+| 422 | `ROUND_NOT_ACTIVE` | Round is not in `ACTIVE` status. |
+| 422 | `ROUND_LOCKED` | Round is locked before resolution. |
+| 500 | `CONFIGURATION_ERROR` | Server misconfiguration. Operator action required. |
+| 500 | `INTERNAL_SERVER_ERROR` | Unexpected. Retry; include `requestId` if reporting. |
+| 503 | `EXTERNAL_SERVICE_ERROR` | Upstream (DB, RPC, oracle) failure. Retry with backoff. |
+
+---
+
+## Production-Readiness Scorecard (#197)
+
+`npm run scorecard` runs a small, zero-dependency set of "is this repo
+ready to deploy?" heuristics and prints a green / yellow / red
+breakdown. CI runs the same script in its own job
+([`.github/workflows/ci.yml`](.github/workflows/ci.yml)) and fails the
+build only when a **required** check fails — soft "nice to have"
+checks emit warnings without blocking merges. New checks live in
+[`scripts/production-readiness-scorecard.js`](scripts/production-readiness-scorecard.js).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:db:teardown": "node scripts/teardown-test-db.js",
     "test:db:reset": "node scripts/reset-test-db.js",
     "ci": "npm run lint && npm run build && npm run test:unit:coverage && npm run test:integration",
+    "scorecard": "node scripts/production-readiness-scorecard.js",
     "install-bindings": "node scripts/install-bindings.js",
     "preinstall": "node scripts/install-bindings.js || true",
     "postinstall": "npm run build",

--- a/prisma/migrations/20260530000000_add_multiplayer_session/migration.sql
+++ b/prisma/migrations/20260530000000_add_multiplayer_session/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "MultiplayerSession" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "walletAddress" TEXT NOT NULL,
+    "socketId" TEXT,
+    "rooms" JSONB NOT NULL DEFAULT '[]',
+    "metadata" JSONB,
+    "connectedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "disconnectedAt" TIMESTAMP(3),
+
+    CONSTRAINT "MultiplayerSession_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MultiplayerSession_userId_key" ON "MultiplayerSession"("userId");
+
+-- CreateIndex
+CREATE INDEX "MultiplayerSession_walletAddress_idx" ON "MultiplayerSession"("walletAddress");
+
+-- CreateIndex
+CREATE INDEX "MultiplayerSession_lastSeenAt_idx" ON "MultiplayerSession"("lastSeenAt");
+
+-- AddForeignKey
+ALTER TABLE "MultiplayerSession" ADD CONSTRAINT "MultiplayerSession_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,13 +73,14 @@ model User {
 
 
   // Relations
-  messages       Message[]
-  predictions    Prediction[]
-  rounds         Round[]
-  notifications  Notification[]
-  authChallenges AuthChallenge[]
-  stats          UserStats?
-  transactions   Transaction[]
+  messages            Message[]
+  predictions         Prediction[]
+  rounds              Round[]
+  notifications       Notification[]
+  authChallenges      AuthChallenge[]
+  stats               UserStats?
+  transactions        Transaction[]
+  multiplayerSessions MultiplayerSession[]
 }
 
 model Message {
@@ -205,6 +206,37 @@ model Transaction {
 
   @@index([userId])
   @@index([type])
+}
+
+/// Multiplayer session metadata persisted across socket disconnects.
+///
+/// Powers reconnect continuity (Issue #194): when an authenticated client
+/// reconnects after a transient drop, the server can look up its prior
+/// rooms and resume membership without forcing the client to re-discover
+/// state. Rows are upserted by `userId` (one active session row per user),
+/// so a fresh login transparently replaces a stale row.
+///
+/// Storage notes:
+///   - `rooms` is a JSON-encoded `string[]` of room names the user joined.
+///   - `metadata` is opaque JSON for future per-game state (last round,
+///     pending message, etc.); writers must keep it bounded.
+///   - `disconnectedAt` is null while the session is live; setting it
+///     marks the session as resumable until cleaned up by retention.
+model MultiplayerSession {
+  id             String   @id @default(uuid())
+  userId         String
+  user           User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  walletAddress  String
+  socketId       String?
+  rooms          Json     @default("[]")
+  metadata       Json?
+  connectedAt    DateTime @default(now())
+  lastSeenAt     DateTime @default(now())
+  disconnectedAt DateTime?
+
+  @@unique([userId])
+  @@index([walletAddress])
+  @@index([lastSeenAt])
 }
 
 model RateLimitMetric {

--- a/scripts/production-readiness-scorecard.js
+++ b/scripts/production-readiness-scorecard.js
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+/**
+ * Production-readiness scorecard (#197).
+ *
+ * Walks a small set of "is this repo ready to run in production?"
+ * heuristics that don't require running the app, and prints a green/red
+ * scorecard. CI calls this; the exit code is non-zero only when a check
+ * marked `required` fails, so the scorecard can ship soft "nice to have"
+ * checks without blocking merges right away.
+ *
+ * Each check returns:
+ *   { name, status: "pass" | "warn" | "fail", required: boolean, detail: string }
+ *
+ * Why this lives as a plain Node script:
+ *   - It runs before the TypeScript build, so it can flag a missing
+ *     build artifact instead of crashing the CI step that needs it.
+ *   - No extra deps; uses only the Node standard library so it is
+ *     trivially auditable.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = path.resolve(__dirname, "..");
+const pkgPath = path.join(ROOT, "package.json");
+const pkg = fs.existsSync(pkgPath)
+  ? JSON.parse(fs.readFileSync(pkgPath, "utf8"))
+  : {};
+
+function fileExists(relPath) {
+  return fs.existsSync(path.join(ROOT, relPath));
+}
+
+function packageHas(field, value) {
+  return Boolean(pkg?.[field]?.[value]);
+}
+
+function readFileMaybe(relPath) {
+  try {
+    return fs.readFileSync(path.join(ROOT, relPath), "utf8");
+  } catch {
+    return null;
+  }
+}
+
+const checks = [
+  {
+    name: "package.json declares a `start` script",
+    required: true,
+    run: () => packageHas("scripts", "start"),
+    detail:
+      "Production deploys run `npm start`. Without it, the build artifact has no documented entrypoint.",
+  },
+  {
+    name: "package.json declares a `build` script",
+    required: true,
+    run: () => packageHas("scripts", "build"),
+    detail: "CI builds via `npm run build` before deploy.",
+  },
+  {
+    name: "package.json declares a `lint` script",
+    required: true,
+    run: () => packageHas("scripts", "lint"),
+    detail: "Type-only lint (tsc --noEmit) protects deploys from regressing types.",
+  },
+  {
+    name: "package.json declares a `test` script",
+    required: true,
+    run: () => packageHas("scripts", "test"),
+    detail: "Required so CI can gate merges on the test suite.",
+  },
+  {
+    name: ".env.example exists",
+    required: true,
+    run: () => fileExists(".env.example"),
+    detail:
+      "Operators copy `.env.example` to `.env`. A missing example invites copy-paste secrets from teammate chat.",
+  },
+  {
+    name: "Prisma schema is present and committed",
+    required: true,
+    run: () => fileExists("prisma/schema.prisma"),
+    detail: "Schema is the single source of truth for the database.",
+  },
+  {
+    name: "CI workflow exists",
+    required: true,
+    run: () => fileExists(".github/workflows/ci.yml"),
+    detail: "No CI = no gate. Merges should be blocked on green CI.",
+  },
+  {
+    name: "Deploy workflow exists",
+    required: false,
+    run: () => fileExists(".github/workflows/deploy.yml"),
+    detail:
+      "A separate deploy workflow keeps CI fast and prevents accidental side effects in non-deploy runs.",
+  },
+  {
+    name: "README documents the health endpoint",
+    required: false,
+    run: () => {
+      const readme = readFileMaybe("README.md");
+      return readme ? /\/health/.test(readme) : false;
+    },
+    detail:
+      "Document `/health` so platform health checks (Render, k8s probes, ELB) can be wired without source diving.",
+  },
+  {
+    name: "Vendored bindings install script is checked in",
+    required: false,
+    run: () => fileExists("scripts/install-bindings.js"),
+    detail:
+      "Production builds rely on vendor/xelma-bindings. The install script makes that reproducible.",
+  },
+  {
+    name: "JWT_SECRET is referenced in .env.example (not hard-coded)",
+    required: true,
+    run: () => {
+      const env = readFileMaybe(".env.example");
+      return env ? /JWT_SECRET\s*=/.test(env) : false;
+    },
+    detail:
+      "Server fails fast without JWT_SECRET; an example placeholder makes that obvious during onboarding.",
+  },
+];
+
+function statusFor(result) {
+  if (result.passed) return "pass";
+  return result.required ? "fail" : "warn";
+}
+
+function render(rows) {
+  const colorize = process.stdout.isTTY;
+  const paint = (s, code) => (colorize ? `[${code}m${s}[0m` : s);
+  const badges = {
+    pass: paint("PASS", "32"),
+    warn: paint("WARN", "33"),
+    fail: paint("FAIL", "31"),
+  };
+  for (const row of rows) {
+    const tag = row.required ? " [required]" : "";
+    console.log(`  ${badges[row.status]}  ${row.name}${tag}`);
+    if (row.status !== "pass") {
+      console.log(`         ${row.detail}`);
+    }
+  }
+}
+
+function main() {
+  console.log("Production-readiness scorecard");
+  console.log("==============================");
+
+  const results = checks.map((check) => {
+    const passed = Boolean(check.run());
+    return {
+      name: check.name,
+      required: check.required,
+      detail: check.detail,
+      passed,
+      status: statusFor({ passed, required: check.required }),
+    };
+  });
+
+  render(results);
+
+  const failures = results.filter((r) => r.status === "fail");
+  const warnings = results.filter((r) => r.status === "warn");
+  const passes = results.filter((r) => r.status === "pass");
+
+  console.log("");
+  console.log(
+    `Summary: ${passes.length} passing, ${warnings.length} warnings, ${failures.length} failing required checks.`,
+  );
+
+  if (failures.length > 0) {
+    console.error("");
+    console.error("Required production-readiness checks failed.");
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { metricsMiddleware } from './middleware/metrics.middleware';
 import { requestIdMiddleware } from './middleware/requestId.middleware';
 import metricsRoutes from './routes/metrics.routes';
 import adminMetricsRoutes from './routes/admin-metrics.routes';
+import errorsRoutes from './routes/errors.routes';
 import chatRoutes from "./routes/chat.routes";
 import swaggerUi from 'swagger-ui-express';
 import { swaggerSpec } from './docs/openapi';
@@ -136,6 +137,7 @@ export function createApp(): Express {
   app.use("/api/chat", chatRoutes);
   app.use("/api/notifications", notificationsRoutes);
   app.use("/api/admin/metrics", adminMetricsRoutes);
+  app.use("/api/errors", errorsRoutes);
 
   // Prometheus metrics endpoint
   app.use('/metrics', metricsRoutes);

--- a/src/routes/errors.routes.ts
+++ b/src/routes/errors.routes.ts
@@ -1,0 +1,45 @@
+import { Router, Request, Response } from "express";
+
+import { ERROR_CATALOG } from "../utils/errors";
+
+const router = Router();
+
+/**
+ * @openapi
+ * /errors:
+ *   get:
+ *     summary: Backend error code catalog (#196)
+ *     description: |
+ *       Returns the canonical list of error codes the API can emit, along
+ *       with the HTTP status, the AppError subclass, and a short
+ *       human-readable description for each. Use this to build client-side
+ *       error-handling switches and to drive the public docs.
+ *     tags:
+ *       - Meta
+ *     responses:
+ *       200:
+ *         description: Catalog of error codes
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 entries:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       code:
+ *                         type: string
+ *                       status:
+ *                         type: integer
+ *                       errorClass:
+ *                         type: string
+ *                       description:
+ *                         type: string
+ */
+router.get("/", (_req: Request, res: Response) => {
+  res.json({ entries: ERROR_CATALOG });
+});
+
+export default router;

--- a/src/services/multiplayer-session.service.ts
+++ b/src/services/multiplayer-session.service.ts
@@ -1,0 +1,268 @@
+/**
+ * Multiplayer session persistence (Issue #194).
+ *
+ * Powers reconnect continuity for authenticated socket clients. Every method
+ * is best-effort with respect to the caller — `socket.ts` calls these from
+ * connection/disconnect handlers, and a DB hiccup must never tear down a
+ * live socket. All public methods therefore:
+ *
+ *   - swallow errors internally and log them at WARN level;
+ *   - return `null` (or an empty resume payload) instead of throwing;
+ *   - hold no in-memory state between calls — the DB is the source of truth.
+ *
+ * Schema is `MultiplayerSession` (see prisma/schema.prisma) with a UNIQUE
+ * constraint on `userId`, so one row per authenticated user. A fresh login
+ * upserts; reconnects update the same row.
+ */
+import { Prisma } from '@prisma/client';
+import { prisma } from '../lib/prisma';
+import logger from '../utils/logger';
+
+/** Maximum number of rooms we will persist in `rooms` per session. */
+export const MAX_PERSISTED_ROOMS = 32;
+
+/** Maximum serialized size (chars) of the opaque `metadata` blob. */
+export const MAX_METADATA_CHARS = 4_096;
+
+/** Payload returned on resume. Empty arrays / nulls mean "nothing to restore". */
+export interface ResumePayload {
+  rooms: string[];
+  metadata: Record<string, unknown> | null;
+  lastSeenAt: string | null;
+  disconnectedAt: string | null;
+}
+
+const EMPTY_RESUME: ResumePayload = {
+  rooms: [],
+  metadata: null,
+  lastSeenAt: null,
+  disconnectedAt: null,
+};
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((v): v is string => typeof v === 'string');
+}
+
+function asJsonObject(value: unknown): Record<string, unknown> | null {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+function clampRooms(rooms: string[]): string[] {
+  // Dedupe while preserving order (first-seen wins) and cap length.
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const r of rooms) {
+    if (typeof r !== 'string' || r.length === 0) continue;
+    if (seen.has(r)) continue;
+    seen.add(r);
+    out.push(r);
+    if (out.length >= MAX_PERSISTED_ROOMS) break;
+  }
+  return out;
+}
+
+function clampMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+): Record<string, unknown> | null {
+  if (!metadata) return null;
+  try {
+    const serialized = JSON.stringify(metadata);
+    if (serialized.length > MAX_METADATA_CHARS) {
+      logger.warn(
+        `[multiplayer-session] metadata exceeds ${MAX_METADATA_CHARS} chars; dropping`,
+      );
+      return null;
+    }
+    return metadata;
+  } catch {
+    return null;
+  }
+}
+
+class MultiplayerSessionService {
+  /**
+   * Mark a user as connected on the given socket. Idempotent: re-running
+   * with the same userId updates the existing row (recording the new
+   * socketId and clearing `disconnectedAt`).
+   *
+   * Returns the prior session's resume payload so the caller can replay
+   * room membership to the client.
+   */
+  async recordConnect(params: {
+    userId: string;
+    walletAddress: string;
+    socketId: string;
+  }): Promise<ResumePayload> {
+    const { userId, walletAddress, socketId } = params;
+    try {
+      const now = new Date();
+      // Snapshot the prior row (if any) BEFORE upserting so the caller can
+      // resume from the last known good state.
+      const prior = await prisma.multiplayerSession.findUnique({
+        where: { userId },
+      });
+
+      await prisma.multiplayerSession.upsert({
+        where: { userId },
+        create: {
+          userId,
+          walletAddress,
+          socketId,
+          rooms: [],
+          connectedAt: now,
+          lastSeenAt: now,
+          disconnectedAt: null,
+        },
+        update: {
+          walletAddress,
+          socketId,
+          lastSeenAt: now,
+          disconnectedAt: null,
+          // Preserve prior `rooms` and `metadata` so reconnect can resume.
+        },
+      });
+
+      if (!prior) return EMPTY_RESUME;
+      return {
+        rooms: asStringArray(prior.rooms),
+        metadata: asJsonObject(prior.metadata),
+        lastSeenAt: prior.lastSeenAt ? prior.lastSeenAt.toISOString() : null,
+        disconnectedAt: prior.disconnectedAt
+          ? prior.disconnectedAt.toISOString()
+          : null,
+      };
+    } catch (error) {
+      logger.warn(
+        `[multiplayer-session] recordConnect failed for user ${userId}: ${(error as Error).message}`,
+      );
+      return EMPTY_RESUME;
+    }
+  }
+
+  /** Add a room to the persisted set (no-op if already present). */
+  async addRoom(userId: string, room: string): Promise<void> {
+    if (!userId || !room) return;
+    try {
+      const session = await prisma.multiplayerSession.findUnique({
+        where: { userId },
+      });
+      if (!session) return;
+      const next = clampRooms([...asStringArray(session.rooms), room]);
+      await prisma.multiplayerSession.update({
+        where: { userId },
+        data: { rooms: next, lastSeenAt: new Date() },
+      });
+    } catch (error) {
+      logger.warn(
+        `[multiplayer-session] addRoom(${room}) failed for user ${userId}: ${(error as Error).message}`,
+      );
+    }
+  }
+
+  /** Remove a room from the persisted set (no-op if absent). */
+  async removeRoom(userId: string, room: string): Promise<void> {
+    if (!userId || !room) return;
+    try {
+      const session = await prisma.multiplayerSession.findUnique({
+        where: { userId },
+      });
+      if (!session) return;
+      const next = asStringArray(session.rooms).filter(r => r !== room);
+      await prisma.multiplayerSession.update({
+        where: { userId },
+        data: { rooms: next, lastSeenAt: new Date() },
+      });
+    } catch (error) {
+      logger.warn(
+        `[multiplayer-session] removeRoom(${room}) failed for user ${userId}: ${(error as Error).message}`,
+      );
+    }
+  }
+
+  /**
+   * Merge opaque metadata into the persisted session. Callers should keep
+   * metadata small (last round id, draft message, etc.). Oversized blobs
+   * are dropped silently — see `MAX_METADATA_CHARS`.
+   */
+  async patchMetadata(
+    userId: string,
+    patch: Record<string, unknown>,
+  ): Promise<void> {
+    if (!userId) return;
+    try {
+      const session = await prisma.multiplayerSession.findUnique({
+        where: { userId },
+      });
+      if (!session) return;
+      const current = asJsonObject(session.metadata) ?? {};
+      const merged = clampMetadata({ ...current, ...patch });
+      await prisma.multiplayerSession.update({
+        where: { userId },
+        data: {
+          metadata:
+            merged !== null ? (merged as Prisma.InputJsonValue) : undefined,
+          lastSeenAt: new Date(),
+        },
+      });
+    } catch (error) {
+      logger.warn(
+        `[multiplayer-session] patchMetadata failed for user ${userId}: ${(error as Error).message}`,
+      );
+    }
+  }
+
+  /**
+   * Mark the session as disconnected. The row is preserved (not deleted)
+   * so a future reconnect can restore rooms; retention/cleanup is the
+   * responsibility of a separate sweeper if/when one is added.
+   */
+  async recordDisconnect(userId: string): Promise<void> {
+    if (!userId) return;
+    try {
+      const now = new Date();
+      await prisma.multiplayerSession.updateMany({
+        where: { userId },
+        data: { disconnectedAt: now, lastSeenAt: now, socketId: null },
+      });
+    } catch (error) {
+      logger.warn(
+        `[multiplayer-session] recordDisconnect failed for user ${userId}: ${(error as Error).message}`,
+      );
+    }
+  }
+
+  /**
+   * Read the resume payload without mutating the row. Used by clients that
+   * want to query state ahead of joining (e.g. for a custom UI flow).
+   */
+  async getResumePayload(userId: string): Promise<ResumePayload> {
+    if (!userId) return EMPTY_RESUME;
+    try {
+      const session = await prisma.multiplayerSession.findUnique({
+        where: { userId },
+      });
+      if (!session) return EMPTY_RESUME;
+      return {
+        rooms: asStringArray(session.rooms),
+        metadata: asJsonObject(session.metadata),
+        lastSeenAt: session.lastSeenAt
+          ? session.lastSeenAt.toISOString()
+          : null,
+        disconnectedAt: session.disconnectedAt
+          ? session.disconnectedAt.toISOString()
+          : null,
+      };
+    } catch (error) {
+      logger.warn(
+        `[multiplayer-session] getResumePayload failed for user ${userId}: ${(error as Error).message}`,
+      );
+      return EMPTY_RESUME;
+    }
+  }
+}
+
+export default new MultiplayerSessionService();

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -4,6 +4,7 @@ import { verifyToken } from './utils/jwt.util';
 import { prisma } from './lib/prisma';
 import websocketService from './services/websocket.service';
 import chatService from './services/chat.service';
+import multiplayerSessionService from './services/multiplayer-session.service';
 import { ChatMessage } from './types/chat.types';
 import logger from './utils/logger';
 
@@ -296,6 +297,31 @@ export function initializeSocket(httpServer: HTTPServer): SocketIOServer {
     if (socket.userId) {
       socket.join(`user:${socket.userId}`);
       logger.info(`Socket ${socket.id} auto-joined user:${socket.userId}`);
+
+      // Issue #194: persist session metadata for reconnect continuity.
+      // Fire-and-forget; a DB failure must never tear down a live socket.
+      const userIdSnapshot = socket.userId;
+      const walletSnapshot = socket.walletAddress ?? '';
+      multiplayerSessionService
+        .recordConnect({
+          userId: userIdSnapshot,
+          walletAddress: walletSnapshot,
+          socketId: socket.id,
+        })
+        .then((resume) => {
+          // Auto-rejoin rooms the user occupied before the drop. The
+          // client also receives the resume payload so it can update
+          // local UI state without a round-trip.
+          for (const room of resume.rooms) {
+            socket.join(room);
+          }
+          socket.emit('session:resume', resume);
+        })
+        .catch((err) => {
+          logger.warn(
+            `recordConnect failed for socket ${socket.id}: ${(err as Error).message}`,
+          );
+        });
     }
 
     // Join round room for price updates and round events
@@ -303,6 +329,9 @@ export function initializeSocket(httpServer: HTTPServer): SocketIOServer {
       socket.join('round');
       logger.info(`Socket ${socket.id} joined room: round`);
       socket.emit('room:joined', { room: 'round' });
+      if (socket.userId) {
+        void multiplayerSessionService.addRoom(socket.userId, 'round');
+      }
     });
 
     // Leave round room
@@ -310,6 +339,9 @@ export function initializeSocket(httpServer: HTTPServer): SocketIOServer {
       socket.leave('round');
       logger.info(`Socket ${socket.id} left room: round`);
       socket.emit('room:left', { room: 'round' });
+      if (socket.userId) {
+        void multiplayerSessionService.removeRoom(socket.userId, 'round');
+      }
     });
 
     // Join chat room (requires authentication)
@@ -321,6 +353,7 @@ export function initializeSocket(httpServer: HTTPServer): SocketIOServer {
       socket.join('chat');
       logger.info(`Socket ${socket.id} joined room: chat`);
       socket.emit('room:joined', { room: 'chat' });
+      void multiplayerSessionService.addRoom(socket.userId, 'chat');
     });
 
     // Leave chat room
@@ -328,6 +361,9 @@ export function initializeSocket(httpServer: HTTPServer): SocketIOServer {
       socket.leave('chat');
       logger.info(`Socket ${socket.id} left room: chat`);
       socket.emit('room:left', { room: 'chat' });
+      if (socket.userId) {
+        void multiplayerSessionService.removeRoom(socket.userId, 'chat');
+      }
     });
 
     // Handle chat message (requires authentication, rate limited, ack-based)
@@ -375,6 +411,15 @@ export function initializeSocket(httpServer: HTTPServer): SocketIOServer {
       }
       socket.join(`user:${socket.userId}`);
       socket.emit('room:joined', { room: 'notifications' });
+      void multiplayerSessionService.addRoom(socket.userId, `user:${socket.userId}`);
+    });
+
+    // Issue #194: clients can checkpoint opaque session metadata
+    // (e.g. last-viewed round, draft message) so it survives a reconnect.
+    socket.on('session:checkpoint', (patch: Record<string, unknown>) => {
+      if (!socket.userId) return;
+      if (!patch || typeof patch !== 'object' || Array.isArray(patch)) return;
+      void multiplayerSessionService.patchMetadata(socket.userId, patch);
     });
 
     // -----------------------------------------------------------------------
@@ -384,6 +429,9 @@ export function initializeSocket(httpServer: HTTPServer): SocketIOServer {
     socket.on('disconnect', (reason) => {
       connectionRegistry.delete(socket.id);
       logger.info(`Client disconnected: ${socket.id}, reason: ${reason}`);
+      if (socket.userId) {
+        void multiplayerSessionService.recordDisconnect(socket.userId);
+      }
     });
 
     // Handle errors

--- a/src/tests/auth-security-regression.spec.ts
+++ b/src/tests/auth-security-regression.spec.ts
@@ -1,0 +1,406 @@
+/**
+ * Issue #195 — Expand auth security regression suite for replay/tamper vectors.
+ *
+ * Companion to:
+ *   - src/tests/auth.routes.spec.ts (happy-path + basic validation)
+ *   - src/tests/auth-race.spec.ts (DB-backed concurrent connect)
+ *
+ * This file focuses on attack vectors those suites do not cover:
+ *   1. Replay: re-using a consumed challenge after a successful connect.
+ *   2. Tamper: swapping wallets, swapping challenges, mutating signatures.
+ *   3. Expired/used short-circuit semantics on the atomic updateMany guard.
+ *   4. Input-shape attacks: oversized signatures, non-string types,
+ *      empty strings, control characters, header-injection style payloads.
+ *
+ * All tests run with mocked Prisma + Stellar, so they execute without a DB.
+ */
+import { describe, it, expect, beforeAll, beforeEach } from "@jest/globals";
+import request from "supertest";
+import { Express } from "express";
+import { createApp } from "../index";
+import * as stellarService from "../services/stellar.service";
+
+jest.mock("../services/stellar.service", () => ({
+  verifySignature: jest.fn(),
+  isValidStellarAddress: jest.fn(),
+}));
+
+// Bypass rate limiters: we are exercising security semantics, not throttling.
+jest.mock("../middleware/rateLimiter.middleware", () => ({
+  challengeRateLimiter: (_req: any, _res: any, next: any) => next(),
+  connectRateLimiter: (_req: any, _res: any, next: any) => next(),
+  authRateLimiter: (_req: any, _res: any, next: any) => next(),
+  chatMessageRateLimiter: (_req: any, _res: any, next: any) => next(),
+  predictionRateLimiter: (_req: any, _res: any, next: any) => next(),
+  adminRoundRateLimiter: (_req: any, _res: any, next: any) => next(),
+  oracleResolveRateLimiter: (_req: any, _res: any, next: any) => next(),
+}));
+
+const mockVerifySignature = stellarService.verifySignature as jest.MockedFunction<
+  typeof stellarService.verifySignature
+>;
+const mockIsValidStellarAddress = stellarService.isValidStellarAddress as jest.MockedFunction<
+  typeof stellarService.isValidStellarAddress
+>;
+
+const mockUserFindUnique = jest.fn();
+const mockUserCreate = jest.fn();
+const mockUserUpdate = jest.fn();
+const mockAuthChallengeFindUnique = jest.fn();
+const mockAuthChallengeFindMany = jest.fn();
+const mockAuthChallengeCreate = jest.fn();
+const mockAuthChallengeUpdateMany = jest.fn();
+const mockAuthChallengeDeleteMany = jest.fn();
+const mockTransactionCreate = jest.fn();
+
+jest.mock("../lib/prisma", () => ({
+  prisma: {
+    user: {
+      findUnique: (...args: any[]) => mockUserFindUnique(...args),
+      create: (...args: any[]) => mockUserCreate(...args),
+      update: (...args: any[]) => mockUserUpdate(...args),
+      deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+    },
+    authChallenge: {
+      findUnique: (...args: any[]) => mockAuthChallengeFindUnique(...args),
+      findMany: (...args: any[]) => mockAuthChallengeFindMany(...args),
+      create: (...args: any[]) => mockAuthChallengeCreate(...args),
+      updateMany: (...args: any[]) => mockAuthChallengeUpdateMany(...args),
+      deleteMany: (...args: any[]) => mockAuthChallengeDeleteMany(...args),
+    },
+    transaction: {
+      create: (...args: any[]) => mockTransactionCreate(...args),
+      deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+    },
+    $disconnect: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+const WALLET_A = "GAAAA_REGRESSION_TEST_WALLET_ONE_______________";
+const WALLET_B = "GBBBB_REGRESSION_TEST_WALLET_TWO_______________";
+const CHALLENGE_A = "xelma_auth_regression_alpha";
+const CHALLENGE_B = "xelma_auth_regression_beta";
+
+function defaultMocks() {
+  mockIsValidStellarAddress.mockReturnValue(true);
+  mockVerifySignature.mockResolvedValue(true);
+  mockAuthChallengeDeleteMany.mockResolvedValue({ count: 0 });
+  mockAuthChallengeFindMany.mockResolvedValue([]);
+  mockUserFindUnique.mockResolvedValue(null);
+  mockAuthChallengeCreate.mockImplementation((args: any) =>
+    Promise.resolve({
+      id: "ch-new",
+      challenge: args?.data?.challenge ?? CHALLENGE_A,
+      walletAddress: args?.data?.walletAddress,
+      expiresAt: args?.data?.expiresAt ?? new Date(Date.now() + 5 * 60 * 1000),
+      isUsed: false,
+    })
+  );
+}
+
+describe("Auth Security Regression Suite (Issue #195)", () => {
+  let app: Express;
+
+  beforeAll(() => {
+    app = createApp();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    defaultMocks();
+  });
+
+  // ----- Replay vectors -----------------------------------------------------
+
+  describe("Replay attacks", () => {
+    it("rejects a second connect with the same challenge after it was consumed", async () => {
+      // First call succeeds: updateMany consumes the row.
+      const future = new Date(Date.now() + 5 * 60 * 1000);
+      mockAuthChallengeUpdateMany.mockResolvedValueOnce({ count: 1 });
+      mockUserCreate.mockResolvedValueOnce({
+        id: "u1",
+        walletAddress: WALLET_A,
+        role: "USER",
+        createdAt: new Date(),
+        lastLoginAt: new Date(),
+      });
+      mockTransactionCreate.mockResolvedValue({});
+
+      const first = await request(app)
+        .post("/api/auth/connect")
+        .send({ walletAddress: WALLET_A, challenge: CHALLENGE_A, signature: "sig" });
+      expect(first.status).toBe(200);
+
+      // Second call: updateMany now matches nothing (challenge already used),
+      // and findUnique sees the row with isUsed=true.
+      mockAuthChallengeUpdateMany.mockResolvedValueOnce({ count: 0 });
+      mockAuthChallengeFindUnique.mockResolvedValueOnce({
+        id: "ch-1",
+        challenge: CHALLENGE_A,
+        walletAddress: WALLET_A,
+        expiresAt: future,
+        isUsed: true,
+        usedAt: new Date(),
+        createdAt: new Date(),
+      });
+
+      const replay = await request(app)
+        .post("/api/auth/connect")
+        .send({ walletAddress: WALLET_A, challenge: CHALLENGE_A, signature: "sig" });
+
+      expect(replay.status).toBe(401);
+      expect(replay.body.message).toContain("already been used");
+    });
+
+    it("rejects connect when challenge is expired even if signature would verify", async () => {
+      const past = new Date(Date.now() - 60 * 1000);
+      // The atomic updateMany filters by `expiresAt > now`, so it matches 0 rows.
+      mockAuthChallengeUpdateMany.mockResolvedValueOnce({ count: 0 });
+      mockAuthChallengeFindUnique.mockResolvedValueOnce({
+        id: "ch-exp",
+        challenge: CHALLENGE_A,
+        walletAddress: WALLET_A,
+        expiresAt: past,
+        isUsed: false,
+        createdAt: new Date(),
+      });
+
+      const res = await request(app)
+        .post("/api/auth/connect")
+        .send({ walletAddress: WALLET_A, challenge: CHALLENGE_A, signature: "sig" });
+
+      expect(res.status).toBe(401);
+      expect(res.body.message).toMatch(/expired/i);
+      // verifySignature must never be invoked when the challenge guard fails.
+      expect(mockVerifySignature).not.toHaveBeenCalled();
+    });
+
+    it("never invokes verifySignature when the challenge does not exist", async () => {
+      mockAuthChallengeUpdateMany.mockResolvedValueOnce({ count: 0 });
+      mockAuthChallengeFindUnique.mockResolvedValueOnce(null);
+
+      const res = await request(app)
+        .post("/api/auth/connect")
+        .send({ walletAddress: WALLET_A, challenge: "nope", signature: "sig" });
+
+      expect(res.status).toBe(401);
+      expect(mockVerifySignature).not.toHaveBeenCalled();
+    });
+  });
+
+  // ----- Tamper vectors -----------------------------------------------------
+
+  describe("Tamper attacks", () => {
+    it("rejects connect when attacker swaps wallet on a victim's challenge", async () => {
+      const future = new Date(Date.now() + 5 * 60 * 1000);
+      // updateMany WHERE clause requires walletAddress to match; attacker's
+      // wallet differs from challenge owner, so 0 rows match.
+      mockAuthChallengeUpdateMany.mockResolvedValueOnce({ count: 0 });
+      mockAuthChallengeFindUnique.mockResolvedValueOnce({
+        id: "ch-vic",
+        challenge: CHALLENGE_A,
+        walletAddress: WALLET_A,
+        expiresAt: future,
+        isUsed: false,
+        createdAt: new Date(),
+      });
+
+      const res = await request(app)
+        .post("/api/auth/connect")
+        .send({ walletAddress: WALLET_B, challenge: CHALLENGE_A, signature: "sig" });
+
+      expect(res.status).toBe(401);
+      expect(res.body.message).toMatch(/invalid or expired/i);
+      expect(mockVerifySignature).not.toHaveBeenCalled();
+    });
+
+    it("rejects connect when signature is for a different challenge string", async () => {
+      const future = new Date(Date.now() + 5 * 60 * 1000);
+      mockAuthChallengeUpdateMany.mockResolvedValueOnce({ count: 1 });
+      mockAuthChallengeFindUnique.mockResolvedValueOnce({
+        id: "ch-1",
+        challenge: CHALLENGE_A,
+        walletAddress: WALLET_A,
+        expiresAt: future,
+        isUsed: true,
+      });
+      // verifySignature returns false because the bytes signed were CHALLENGE_B.
+      mockVerifySignature.mockResolvedValueOnce(false);
+
+      const res = await request(app)
+        .post("/api/auth/connect")
+        .send({
+          walletAddress: WALLET_A,
+          challenge: CHALLENGE_A,
+          signature: "signature-of-different-challenge",
+        });
+
+      expect(res.status).toBe(401);
+      expect(res.body.message).toContain("Invalid signature");
+      // We must have actually verified the wallet+challenge+signature triple.
+      expect(mockVerifySignature).toHaveBeenCalledWith(
+        WALLET_A,
+        CHALLENGE_A,
+        "signature-of-different-challenge"
+      );
+    });
+
+    it("does not leak which of {wallet, challenge} was wrong on mismatch", async () => {
+      // Both "wrong wallet" and "wrong challenge" must surface as the same
+      // generic error so attackers cannot enumerate live wallets.
+      const future = new Date(Date.now() + 5 * 60 * 1000);
+
+      // Case A: challenge exists, attacker uses wrong wallet.
+      mockAuthChallengeUpdateMany.mockResolvedValueOnce({ count: 0 });
+      mockAuthChallengeFindUnique.mockResolvedValueOnce({
+        id: "ch-1",
+        challenge: CHALLENGE_A,
+        walletAddress: WALLET_A,
+        expiresAt: future,
+        isUsed: false,
+      });
+      const wrongWallet = await request(app)
+        .post("/api/auth/connect")
+        .send({ walletAddress: WALLET_B, challenge: CHALLENGE_A, signature: "sig" });
+
+      // Case B: challenge does not exist at all.
+      mockAuthChallengeUpdateMany.mockResolvedValueOnce({ count: 0 });
+      mockAuthChallengeFindUnique.mockResolvedValueOnce(null);
+      const noChallenge = await request(app)
+        .post("/api/auth/connect")
+        .send({ walletAddress: WALLET_B, challenge: "ghost", signature: "sig" });
+
+      expect(wrongWallet.status).toBe(noChallenge.status);
+      expect(wrongWallet.body.message).toBe(noChallenge.body.message);
+      expect(wrongWallet.body.error).toBe(noChallenge.body.error);
+    });
+  });
+
+  // ----- Input-shape attacks ------------------------------------------------
+
+  describe("Malformed input vectors", () => {
+    it("rejects connect when signature is an empty string", async () => {
+      const res = await request(app).post("/api/auth/connect").send({
+        walletAddress: WALLET_A,
+        challenge: CHALLENGE_A,
+        signature: "",
+      });
+      expect(res.status).toBe(400);
+      expect(mockAuthChallengeUpdateMany).not.toHaveBeenCalled();
+    });
+
+    it("rejects connect when signature is not a string", async () => {
+      const res = await request(app)
+        .post("/api/auth/connect")
+        .send({
+          walletAddress: WALLET_A,
+          challenge: CHALLENGE_A,
+          signature: { tampered: true } as any,
+        });
+      expect(res.status).toBe(400);
+      expect(mockAuthChallengeUpdateMany).not.toHaveBeenCalled();
+    });
+
+    it("rejects connect when challenge contains NUL bytes or control chars", async () => {
+      // updateMany should be invoked but match nothing; even if it did,
+      // findUnique returns null so we 401. We assert no crash and no leak.
+      mockAuthChallengeUpdateMany.mockResolvedValueOnce({ count: 0 });
+      mockAuthChallengeFindUnique.mockResolvedValueOnce(null);
+
+      const res = await request(app)
+        .post("/api/auth/connect")
+        .send({
+          walletAddress: WALLET_A,
+          challenge: "xelma_auth_ _ctrl",
+          signature: "sig",
+        });
+
+      expect([400, 401]).toContain(res.status);
+    });
+
+    it("rejects challenge issuance with missing walletAddress and does not touch DB", async () => {
+      const res = await request(app).post("/api/auth/challenge").send({});
+      expect(res.status).toBe(400);
+      expect(mockAuthChallengeCreate).not.toHaveBeenCalled();
+      expect(mockAuthChallengeDeleteMany).not.toHaveBeenCalled();
+    });
+
+    it("rejects invalid Stellar address on challenge issuance and does not touch DB", async () => {
+      mockIsValidStellarAddress.mockReturnValueOnce(false);
+      const res = await request(app)
+        .post("/api/auth/challenge")
+        .send({ walletAddress: "not-a-stellar-address" });
+
+      expect(res.status).toBe(400);
+      expect(mockAuthChallengeCreate).not.toHaveBeenCalled();
+      expect(mockAuthChallengeDeleteMany).not.toHaveBeenCalled();
+    });
+  });
+
+  // ----- Challenge lifecycle invariants ------------------------------------
+
+  describe("Challenge lifecycle invariants", () => {
+    it("invalidates prior unused challenges when a new one is requested", async () => {
+      mockAuthChallengeFindMany.mockResolvedValueOnce([
+        { challenge: "old-1" },
+        { challenge: "old-2" },
+      ]);
+
+      const res = await request(app)
+        .post("/api/auth/challenge")
+        .send({ walletAddress: WALLET_A });
+
+      expect(res.status).toBe(200);
+      // We must have asked the DB to delete prior unused challenges for this
+      // wallet, enforcing the one-active-challenge policy.
+      expect(mockAuthChallengeDeleteMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            walletAddress: WALLET_A,
+            isUsed: false,
+          }),
+        })
+      );
+      // And we must have created exactly one new challenge.
+      expect(mockAuthChallengeCreate).toHaveBeenCalledTimes(1);
+    });
+
+    it("consumes the challenge atomically before verifying the signature", async () => {
+      // Order matters: updateMany must run BEFORE verifySignature so that two
+      // concurrent connects cannot both pass the signature check.
+      const future = new Date(Date.now() + 5 * 60 * 1000);
+      const callOrder: string[] = [];
+
+      mockAuthChallengeUpdateMany.mockImplementationOnce(async () => {
+        callOrder.push("updateMany");
+        return { count: 1 };
+      });
+      mockAuthChallengeFindUnique.mockResolvedValueOnce({
+        id: "ch-1",
+        challenge: CHALLENGE_A,
+        walletAddress: WALLET_A,
+        expiresAt: future,
+        isUsed: true,
+      });
+      mockVerifySignature.mockImplementationOnce(async () => {
+        callOrder.push("verifySignature");
+        return true;
+      });
+      mockUserCreate.mockResolvedValueOnce({
+        id: "u1",
+        walletAddress: WALLET_A,
+        role: "USER",
+        createdAt: new Date(),
+        lastLoginAt: new Date(),
+      });
+      mockTransactionCreate.mockResolvedValue({});
+
+      const res = await request(app)
+        .post("/api/auth/connect")
+        .send({ walletAddress: WALLET_A, challenge: CHALLENGE_A, signature: "sig" });
+
+      expect(res.status).toBe(200);
+      expect(callOrder).toEqual(["updateMany", "verifySignature"]);
+    });
+  });
+});

--- a/src/tests/error-catalog.spec.ts
+++ b/src/tests/error-catalog.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Regression coverage for #196 — the unified error code catalog.
+ *
+ * If a new ErrorCode is added without a matching ERROR_CATALOG entry,
+ * the test fails so the catalog cannot silently drift out of sync
+ * with the enum API clients depend on. Also pins per-code HTTP status
+ * and ensures every entry has a description (so API consumers always
+ * have something actionable).
+ */
+import { describe, it, expect } from "@jest/globals";
+
+import { ErrorCode, ERROR_CATALOG } from "../utils/errors";
+
+describe("ERROR_CATALOG", () => {
+  it("covers every ErrorCode enum value exactly once", () => {
+    const enumValues = Object.values(ErrorCode);
+    const catalogCodes = ERROR_CATALOG.map((entry) => entry.code);
+
+    expect(new Set(catalogCodes).size).toBe(catalogCodes.length);
+    expect(new Set(catalogCodes)).toEqual(new Set(enumValues));
+  });
+
+  it("pins every entry to a sensible HTTP status (4xx or 5xx)", () => {
+    for (const entry of ERROR_CATALOG) {
+      expect(entry.status).toBeGreaterThanOrEqual(400);
+      expect(entry.status).toBeLessThan(600);
+    }
+  });
+
+  it("never ships a blank description", () => {
+    for (const entry of ERROR_CATALOG) {
+      expect(entry.description.length).toBeGreaterThan(20);
+    }
+  });
+
+  it("uses status 401 for every challenge-flow error", () => {
+    const challengeCodes = [
+      ErrorCode.INVALID_CHALLENGE,
+      ErrorCode.CHALLENGE_EXPIRED,
+      ErrorCode.CHALLENGE_USED,
+      ErrorCode.INVALID_SIGNATURE,
+    ];
+    for (const code of challengeCodes) {
+      const entry = ERROR_CATALOG.find((e) => e.code === code);
+      expect(entry?.status).toBe(401);
+    }
+  });
+});

--- a/src/tests/multiplayer-session.service.spec.ts
+++ b/src/tests/multiplayer-session.service.spec.ts
@@ -1,0 +1,303 @@
+/**
+ * Issue #194 — multiplayer-session.service unit tests.
+ *
+ * Verifies the persistence semantics that power reconnect continuity:
+ *   - recordConnect upserts and snapshots the prior row.
+ *   - addRoom / removeRoom mutate `rooms` immutably and dedupe.
+ *   - patchMetadata merges and clamps oversized blobs.
+ *   - recordDisconnect preserves the row and stamps disconnectedAt.
+ *   - all methods swallow DB errors instead of throwing.
+ */
+import { describe, it, expect, beforeEach } from '@jest/globals';
+
+const mockSessionFindUnique = jest.fn();
+const mockSessionUpsert = jest.fn();
+const mockSessionUpdate = jest.fn();
+const mockSessionUpdateMany = jest.fn();
+
+jest.mock('../lib/prisma', () => ({
+  prisma: {
+    multiplayerSession: {
+      findUnique: (...args: any[]) => mockSessionFindUnique(...args),
+      upsert: (...args: any[]) => mockSessionUpsert(...args),
+      update: (...args: any[]) => mockSessionUpdate(...args),
+      updateMany: (...args: any[]) => mockSessionUpdateMany(...args),
+    },
+  },
+}));
+
+// Import AFTER mocks are in place.
+import multiplayerSessionService, {
+  MAX_PERSISTED_ROOMS,
+  MAX_METADATA_CHARS,
+} from '../services/multiplayer-session.service';
+
+const USER_ID = 'user-194';
+const WALLET = 'GMULTIPLAYER_SESSION_TEST_WALLET_______________';
+const SOCKET_ID = 'sock-abc';
+
+describe('MultiplayerSessionService (Issue #194)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('recordConnect', () => {
+    it('returns empty resume payload on first connect (no prior row)', async () => {
+      mockSessionFindUnique.mockResolvedValueOnce(null);
+      mockSessionUpsert.mockResolvedValueOnce({});
+
+      const resume = await multiplayerSessionService.recordConnect({
+        userId: USER_ID,
+        walletAddress: WALLET,
+        socketId: SOCKET_ID,
+      });
+
+      expect(resume).toEqual({
+        rooms: [],
+        metadata: null,
+        lastSeenAt: null,
+        disconnectedAt: null,
+      });
+      expect(mockSessionUpsert).toHaveBeenCalledTimes(1);
+      const args = mockSessionUpsert.mock.calls[0][0];
+      expect(args.where).toEqual({ userId: USER_ID });
+      expect(args.create.walletAddress).toBe(WALLET);
+      expect(args.create.socketId).toBe(SOCKET_ID);
+      expect(args.update.disconnectedAt).toBeNull();
+    });
+
+    it('returns prior rooms + metadata on reconnect', async () => {
+      const lastSeen = new Date('2026-05-30T10:00:00.000Z');
+      const disconnectedAt = new Date('2026-05-30T10:05:00.000Z');
+      mockSessionFindUnique.mockResolvedValueOnce({
+        userId: USER_ID,
+        walletAddress: WALLET,
+        rooms: ['round', 'chat'],
+        metadata: { lastRoundId: 'r-1' },
+        lastSeenAt: lastSeen,
+        disconnectedAt,
+      });
+      mockSessionUpsert.mockResolvedValueOnce({});
+
+      const resume = await multiplayerSessionService.recordConnect({
+        userId: USER_ID,
+        walletAddress: WALLET,
+        socketId: 'new-socket',
+      });
+
+      expect(resume.rooms).toEqual(['round', 'chat']);
+      expect(resume.metadata).toEqual({ lastRoundId: 'r-1' });
+      expect(resume.lastSeenAt).toBe(lastSeen.toISOString());
+      expect(resume.disconnectedAt).toBe(disconnectedAt.toISOString());
+
+      // upsert.update must NOT clobber rooms or metadata — those are
+      // preserved server-side so the resume is meaningful.
+      const updateArgs = mockSessionUpsert.mock.calls[0][0].update;
+      expect(updateArgs.rooms).toBeUndefined();
+      expect(updateArgs.metadata).toBeUndefined();
+      expect(updateArgs.disconnectedAt).toBeNull();
+      expect(updateArgs.socketId).toBe('new-socket');
+    });
+
+    it('filters non-string entries out of prior rooms', async () => {
+      mockSessionFindUnique.mockResolvedValueOnce({
+        userId: USER_ID,
+        rooms: ['round', 42, null, 'chat'] as unknown as string[],
+        metadata: null,
+        lastSeenAt: new Date(),
+        disconnectedAt: null,
+      });
+      mockSessionUpsert.mockResolvedValueOnce({});
+
+      const resume = await multiplayerSessionService.recordConnect({
+        userId: USER_ID,
+        walletAddress: WALLET,
+        socketId: SOCKET_ID,
+      });
+
+      expect(resume.rooms).toEqual(['round', 'chat']);
+    });
+
+    it('returns empty payload (does not throw) on DB error', async () => {
+      mockSessionFindUnique.mockRejectedValueOnce(new Error('db down'));
+
+      const resume = await multiplayerSessionService.recordConnect({
+        userId: USER_ID,
+        walletAddress: WALLET,
+        socketId: SOCKET_ID,
+      });
+
+      expect(resume).toEqual({
+        rooms: [],
+        metadata: null,
+        lastSeenAt: null,
+        disconnectedAt: null,
+      });
+    });
+  });
+
+  describe('addRoom / removeRoom', () => {
+    it('appends a new room without duplicating existing entries', async () => {
+      mockSessionFindUnique.mockResolvedValueOnce({
+        rooms: ['round'],
+      });
+      mockSessionUpdate.mockResolvedValueOnce({});
+
+      await multiplayerSessionService.addRoom(USER_ID, 'chat');
+
+      const args = mockSessionUpdate.mock.calls[0][0];
+      expect(args.data.rooms).toEqual(['round', 'chat']);
+    });
+
+    it('is a no-op when the room is already present', async () => {
+      mockSessionFindUnique.mockResolvedValueOnce({
+        rooms: ['round', 'chat'],
+      });
+      mockSessionUpdate.mockResolvedValueOnce({});
+
+      await multiplayerSessionService.addRoom(USER_ID, 'chat');
+
+      const args = mockSessionUpdate.mock.calls[0][0];
+      expect(args.data.rooms).toEqual(['round', 'chat']);
+    });
+
+    it('caps persisted rooms at MAX_PERSISTED_ROOMS', async () => {
+      const tooMany = Array.from({ length: MAX_PERSISTED_ROOMS + 5 }, (_, i) => `r${i}`);
+      mockSessionFindUnique.mockResolvedValueOnce({
+        rooms: tooMany,
+      });
+      mockSessionUpdate.mockResolvedValueOnce({});
+
+      await multiplayerSessionService.addRoom(USER_ID, 'one-more');
+
+      const args = mockSessionUpdate.mock.calls[0][0];
+      expect(args.data.rooms.length).toBe(MAX_PERSISTED_ROOMS);
+      // Cap drops the trailing additions, not the originals, so "one-more"
+      // should not be in the persisted list.
+      expect(args.data.rooms).not.toContain('one-more');
+    });
+
+    it('removes the requested room and leaves others intact', async () => {
+      mockSessionFindUnique.mockResolvedValueOnce({
+        rooms: ['round', 'chat', 'user:abc'],
+      });
+      mockSessionUpdate.mockResolvedValueOnce({});
+
+      await multiplayerSessionService.removeRoom(USER_ID, 'chat');
+
+      const args = mockSessionUpdate.mock.calls[0][0];
+      expect(args.data.rooms).toEqual(['round', 'user:abc']);
+    });
+
+    it('does nothing when no session row exists yet', async () => {
+      mockSessionFindUnique.mockResolvedValueOnce(null);
+
+      await multiplayerSessionService.addRoom(USER_ID, 'chat');
+      await multiplayerSessionService.removeRoom(USER_ID, 'chat');
+
+      expect(mockSessionUpdate).not.toHaveBeenCalled();
+    });
+
+    it('swallows DB errors instead of throwing', async () => {
+      mockSessionFindUnique.mockRejectedValueOnce(new Error('boom'));
+      await expect(
+        multiplayerSessionService.addRoom(USER_ID, 'chat'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('ignores empty/invalid input without touching the DB', async () => {
+      await multiplayerSessionService.addRoom('', 'chat');
+      await multiplayerSessionService.addRoom(USER_ID, '');
+      await multiplayerSessionService.removeRoom('', 'chat');
+      await multiplayerSessionService.removeRoom(USER_ID, '');
+      expect(mockSessionFindUnique).not.toHaveBeenCalled();
+      expect(mockSessionUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('patchMetadata', () => {
+    it('merges patch into existing metadata', async () => {
+      mockSessionFindUnique.mockResolvedValueOnce({
+        metadata: { lastRoundId: 'r-1', draft: 'hi' },
+      });
+      mockSessionUpdate.mockResolvedValueOnce({});
+
+      await multiplayerSessionService.patchMetadata(USER_ID, {
+        draft: 'updated',
+        cursor: 5,
+      });
+
+      const args = mockSessionUpdate.mock.calls[0][0];
+      expect(args.data.metadata).toEqual({
+        lastRoundId: 'r-1',
+        draft: 'updated',
+        cursor: 5,
+      });
+    });
+
+    it('drops oversized metadata silently', async () => {
+      mockSessionFindUnique.mockResolvedValueOnce({ metadata: null });
+      mockSessionUpdate.mockResolvedValueOnce({});
+
+      const huge = { blob: 'x'.repeat(MAX_METADATA_CHARS + 100) };
+      await multiplayerSessionService.patchMetadata(USER_ID, huge);
+
+      // Service should call update with metadata === undefined (i.e. not set)
+      // rather than throwing.
+      const args = mockSessionUpdate.mock.calls[0][0];
+      expect(args.data.metadata).toBeUndefined();
+    });
+  });
+
+  describe('recordDisconnect', () => {
+    it('stamps disconnectedAt and clears socketId via updateMany', async () => {
+      mockSessionUpdateMany.mockResolvedValueOnce({ count: 1 });
+
+      await multiplayerSessionService.recordDisconnect(USER_ID);
+
+      expect(mockSessionUpdateMany).toHaveBeenCalledTimes(1);
+      const args = mockSessionUpdateMany.mock.calls[0][0];
+      expect(args.where).toEqual({ userId: USER_ID });
+      expect(args.data.disconnectedAt).toBeInstanceOf(Date);
+      expect(args.data.socketId).toBeNull();
+    });
+
+    it('does not throw on DB error', async () => {
+      mockSessionUpdateMany.mockRejectedValueOnce(new Error('nope'));
+      await expect(
+        multiplayerSessionService.recordDisconnect(USER_ID),
+      ).resolves.toBeUndefined();
+    });
+
+    it('is a no-op when userId is empty', async () => {
+      await multiplayerSessionService.recordDisconnect('');
+      expect(mockSessionUpdateMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getResumePayload', () => {
+    it('returns the persisted resume snapshot', async () => {
+      const lastSeen = new Date('2026-05-30T11:00:00.000Z');
+      mockSessionFindUnique.mockResolvedValueOnce({
+        rooms: ['round'],
+        metadata: { x: 1 },
+        lastSeenAt: lastSeen,
+        disconnectedAt: null,
+      });
+
+      const out = await multiplayerSessionService.getResumePayload(USER_ID);
+
+      expect(out.rooms).toEqual(['round']);
+      expect(out.metadata).toEqual({ x: 1 });
+      expect(out.lastSeenAt).toBe(lastSeen.toISOString());
+      expect(out.disconnectedAt).toBeNull();
+    });
+
+    it('returns empty payload when no session exists', async () => {
+      mockSessionFindUnique.mockResolvedValueOnce(null);
+      const out = await multiplayerSessionService.getResumePayload(USER_ID);
+      expect(out.rooms).toEqual([]);
+      expect(out.metadata).toBeNull();
+    });
+  });
+});

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -110,3 +110,169 @@ export class ConfigurationError extends AppError {
     super(message, 500, code);
   }
 }
+
+/**
+ * Unified backend error code catalog (#196).
+ *
+ * Single source of truth that maps every {@link ErrorCode} to the
+ * HTTP status the API will use, the error class that produces it, and
+ * a short, human-readable description an API consumer can act on.
+ *
+ * Consumed by:
+ *   - The README for the public error reference table.
+ *   - The OpenAPI doc so each error appears alongside the endpoints
+ *     that can return it.
+ *   - The unit test that pins the catalog and prevents drift from
+ *     the actual ErrorCode enum.
+ */
+export interface ErrorCatalogEntry {
+  /** Machine-readable code shipped on the wire in `error.code`. */
+  code: ErrorCode;
+  /** HTTP status this error maps to in responses. */
+  status: number;
+  /** Name of the AppError subclass that emits this code. */
+  errorClass: string;
+  /** Short, action-oriented description for API consumers. */
+  description: string;
+}
+
+export const ERROR_CATALOG: readonly ErrorCatalogEntry[] = [
+  {
+    code: ErrorCode.VALIDATION_ERROR,
+    status: 400,
+    errorClass: "ValidationError",
+    description:
+      "Request body, query string, or path params failed schema validation. " +
+      "Fix the offending fields described in `error.details`.",
+  },
+  {
+    code: ErrorCode.AUTHENTICATION_ERROR,
+    status: 401,
+    errorClass: "AuthenticationError",
+    description:
+      "Missing, malformed, or invalid credentials. Acquire a fresh JWT via " +
+      "the wallet challenge → connect flow and retry.",
+  },
+  {
+    code: ErrorCode.AUTHORIZATION_ERROR,
+    status: 403,
+    errorClass: "AuthorizationError",
+    description:
+      "Authenticated, but not permitted for this resource or action.",
+  },
+  {
+    code: ErrorCode.NOT_FOUND,
+    status: 404,
+    errorClass: "NotFoundError",
+    description: "The requested resource does not exist.",
+  },
+  {
+    code: ErrorCode.CONFLICT,
+    status: 409,
+    errorClass: "ConflictError",
+    description:
+      "The request conflicts with current server state. Re-read the resource " +
+      "and retry.",
+  },
+  {
+    code: ErrorCode.BUSINESS_RULE_VIOLATION,
+    status: 422,
+    errorClass: "BusinessRuleError",
+    description:
+      "Request was well-formed but violated a domain rule (e.g. round closed, " +
+      "duplicate prediction).",
+  },
+  {
+    code: ErrorCode.EXTERNAL_SERVICE_ERROR,
+    status: 503,
+    errorClass: "ExternalServiceError",
+    description:
+      "Upstream dependency (database, Soroban RPC, oracle) is unavailable or " +
+      "returned an unexpected error. Retry with backoff.",
+  },
+  {
+    code: ErrorCode.CONFIGURATION_ERROR,
+    status: 500,
+    errorClass: "ConfigurationError",
+    description:
+      "Server misconfiguration detected at runtime. Operators must intervene; " +
+      "client retry will not help.",
+  },
+  {
+    code: ErrorCode.INTERNAL_SERVER_ERROR,
+    status: 500,
+    errorClass: "AppError",
+    description:
+      "Unexpected server error. Retry; if it persists, include the response's " +
+      "`requestId` when filing a bug.",
+  },
+  {
+    code: ErrorCode.INVALID_CHALLENGE,
+    status: 401,
+    errorClass: "AuthenticationError",
+    description:
+      "The signed challenge does not match any known issued challenge. Restart " +
+      "the wallet sign-in from the challenge endpoint.",
+  },
+  {
+    code: ErrorCode.CHALLENGE_EXPIRED,
+    status: 401,
+    errorClass: "AuthenticationError",
+    description: "Challenge TTL has elapsed. Request a new challenge and sign it again.",
+  },
+  {
+    code: ErrorCode.CHALLENGE_USED,
+    status: 401,
+    errorClass: "AuthenticationError",
+    description:
+      "Challenge has already been consumed (challenges are one-shot). Request " +
+      "a fresh one.",
+  },
+  {
+    code: ErrorCode.INVALID_SIGNATURE,
+    status: 401,
+    errorClass: "AuthenticationError",
+    description:
+      "Signature does not verify against the supplied wallet address and " +
+      "challenge payload.",
+  },
+  {
+    code: ErrorCode.INSUFFICIENT_FUNDS,
+    status: 422,
+    errorClass: "BusinessRuleError",
+    description:
+      "Wallet does not have the required balance for the requested operation.",
+  },
+  {
+    code: ErrorCode.ROUND_NOT_ACTIVE,
+    status: 422,
+    errorClass: "BusinessRuleError",
+    description: "Target round is not in ACTIVE status and cannot accept this action.",
+  },
+  {
+    code: ErrorCode.ROUND_LOCKED,
+    status: 422,
+    errorClass: "BusinessRuleError",
+    description:
+      "Round has been locked ahead of resolution; predictions are no longer accepted.",
+  },
+  {
+    code: ErrorCode.ROUND_ALREADY_RESOLVED,
+    status: 409,
+    errorClass: "ConflictError",
+    description: "Round has already been resolved and its outcome is final.",
+  },
+  {
+    code: ErrorCode.DUPLICATE_PREDICTION,
+    status: 409,
+    errorClass: "ConflictError",
+    description: "User already has a prediction for this round.",
+  },
+  {
+    code: ErrorCode.ACTIVE_ROUND_EXISTS,
+    status: 409,
+    errorClass: "ConflictError",
+    description:
+      "An active round of the requested mode already exists; start cannot proceed.",
+  },
+];


### PR DESCRIPTION
## Summary

Four backend improvements bundled together:

1. A single drift-checked error-code catalog so API consumers and contributors stop having to grep `errors.ts` to learn what `error.code` values mean.
2. A small, zero-dependency production-readiness scorecard that runs in CI and gives a green / yellow / red view of "is this repo deploy-ready?".
3. Persisted multiplayer session metadata so authenticated socket clients resume their rooms after a reconnect.
4. An expanded auth security regression suite covering replay, tamper, and lifecycle vectors.

closes #196
closes #197
closes #194
closes #195

## Changes

- **#196 — Unified backend error code catalog**:
  - `src/utils/errors.ts`: new `ERROR_CATALOG`, a `readonly ErrorCatalogEntry[]` with one `{ code, status, errorClass, description }` per `ErrorCode` enum value. Catalog ordering is stable so docs are diff-friendly.
  - `src/routes/errors.routes.ts` (new): `GET /api/errors` returns `{ entries: ERROR_CATALOG }` so clients can codegen an exhaustive error-handling switch from the wire.
  - `src/index.ts`: mounts the new route under `/api/errors`.
  - `src/tests/error-catalog.spec.ts` (4 cases): pins the catalog to the `ErrorCode` enum (set equality), enforces every status is in 400–599, requires a non-blank description, and pins every challenge-flow code to HTTP 401.
  - `README.md`: renders the catalog as a Markdown table in a new "Error Code Catalog (#196)" section, plus a link to the new `GET /api/errors` endpoint and to the drift test.

- **#197 — Production-readiness scorecard CI check**:
  - `scripts/production-readiness-scorecard.js` (new): plain Node, no runtime deps. 11 starter checks covering npm scripts (`start`/`build`/`lint`/`test`), `.env.example`, `prisma/schema.prisma`, `.github/workflows/ci.yml`, `deploy.yml`, README mentioning `/health`, the vendored bindings install script, and the `JWT_SECRET` placeholder. Each check declares `required: boolean`; the script exits non-zero only when a *required* check fails, so "nice to have" checks can ship as warnings.
  - `package.json`: new `npm run scorecard` script.
  - `.github/workflows/ci.yml`: new `scorecard` job that runs the scorecard. No `npm ci` — the script is intentionally dep-free so it runs in seconds and works on fresh forks.
  - `README.md`: "Production-Readiness Scorecard (#197)" section + `npm run scorecard` row in the Scripts table.

- **#194 — Persist multiplayer session metadata for reconnect continuity**:
  - `prisma/schema.prisma` + `prisma/migrations/20260530000000_add_multiplayer_session/`: new `MultiplayerSession` model (one row per `userId` via UNIQUE) with `rooms` (JSON `string[]`), opaque `metadata` (JSON), `connectedAt` / `lastSeenAt` / `disconnectedAt`, and a CASCADE FK to `User`. Forward-only migration.
  - `src/services/multiplayer-session.service.ts` (new): `recordConnect` upserts the row and returns the prior row's resume payload (so `socket.ts` can replay rooms); `addRoom` / `removeRoom` are idempotent and capped at 32 entries; `patchMetadata` shallow-merges with a 4 KB clamp; `recordDisconnect` preserves the row and stamps `disconnectedAt`. Every method swallows DB errors and logs at WARN — a DB hiccup must never tear down a live socket.
  - `src/socket.ts`: authenticated connect now `recordConnect`s fire-and-forget, then auto-rejoins the prior rooms server-side and emits a new `session:resume` event. `join:`/`leave:` `round`/`chat`/`notifications` mirror to the persisted list. New `session:checkpoint` event lets clients persist opaque resume state. `disconnect` calls `recordDisconnect`.
  - `src/tests/multiplayer-session.service.spec.ts` (18 cases): empty vs full resume payload, dedupe + cap, metadata merge + clamp, fail-safe DB error handling. Existing `socket.spec.ts` (26 cases) continues to pass.

- **#195 — Expand auth security regression suite for replay/tamper vectors**:
  - `src/tests/auth-security-regression.spec.ts` (new, 13 cases) complements `auth.routes.spec.ts` and `auth-race.spec.ts` with:
    - **Replay**: rejecting a second connect on a consumed challenge; expired-challenge short-circuit; missing-challenge short-circuit. All assert `verifySignature` is never invoked when the challenge guard fails.
    - **Tamper**: attacker swapping wallet on a victim's challenge; signature-of-different-challenge (`verifySignature` returns false); uniform error response for "wrong wallet" vs "no such challenge" so attackers cannot enumerate live wallets.
    - **Input shape**: empty-string / non-string / object signatures (asserts DB is not touched past validation); control-char challenges; missing `walletAddress` on `/challenge`; invalid Stellar address on `/challenge`.
    - **Lifecycle invariants**: prior unused challenges deleted on re-issue; `updateMany` runs before `verifySignature` so concurrent connects cannot both pass (verified by recording call order).
  - All Prisma + Stellar calls are mocked so the new suite runs without a DB and complements the DB-backed `auth-race.spec.ts`.

## Test plan

- `npm run lint` — passes (`tsc --noEmit` clean).
- `npm run build` — passes.
- `npx jest src/tests/error-catalog.spec.ts` — 4/4 passing locally.
- `npx jest src/tests/auth-security-regression.spec.ts` — 13/13 passing locally.
- `npx jest src/tests/multiplayer-session.service.spec.ts` — 18/18 passing locally.
- `npx jest src/tests/socket.spec.ts` — 26/26 still passing (no regression from socket.ts touchpoints).
- `npm run scorecard` — 11/11 passing locally; verified the script exits 1 when a required check fails (smoke-tested by temporarily renaming `prisma/schema.prisma`).

## Risk notes

- `ERROR_CATALOG` is purely additive; existing error code emission is unchanged. The drift test guarantees the catalog cannot fall behind the enum.
- `GET /api/errors` is unauthenticated by design — the catalog is public reference material, contains no runtime secrets, and exposes no state.
- The scorecard CI job is independent of the rest of CI, so its failure mode is isolated.
- The `MultiplayerSession` table is brand-new with no callers outside `socket.ts`, so the migration is purely additive and has no read paths that could break on an unmigrated database. Every service method swallows DB errors, so even if the migration is delayed in some environment, the socket flow degrades gracefully (room joins still work; resume is just unavailable).
- The new `auth-security-regression.spec.ts` is test-only — it adds no runtime code.
