### PR TITLE
feat: harden batch rate limits, operator metrics, auth registry, and …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -131,3 +131,16 @@ RETENTION_CHAT_MESSAGES_TTL_DAYS=90
 
 # Batch size for deletion operations (default: 1000)
 RETENTION_BATCH_SIZE=1000
+
+# -----------------------
+# Rate limiting (batch mutations)
+# -----------------------
+# Stricter limits for high-impact batch endpoints (per authenticated user).
+# BATCH_PREDICTION_RATE_LIMIT_MAX=3
+# BATCH_PREDICTION_RATE_LIMIT_WINDOW_MS=60000
+# BATCH_LEADERBOARD_RATE_LIMIT_MAX=10
+# BATCH_LEADERBOARD_RATE_LIMIT_WINDOW_MS=60000
+
+# Operator suspicious-activity heuristics (admin metrics dashboard)
+# RATE_LIMIT_SUSPICIOUS_HIT_THRESHOLD=5
+# RATE_LIMIT_SUSPICIOUS_LOOKBACK_HOURS=24

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Run build
         run: npm run build
 
+      - name: Verify OpenAPI spec generates required routes
+        run: npm run docs:verify
+
   test-unit:
     name: test (unit)
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -316,8 +316,17 @@ Xelma-Backend/
 - **`requireOracle`**: Ensures user has ORACLE role
 
 #### **Rate Limiter Middleware (`rateLimiter.middleware.ts`)**
-- Prevents API abuse by limiting requests per IP
-- Configurable limits per endpoint
+- Prevents API abuse with per-IP and per-user limits
+- Single prediction submit: 10 requests/minute per user
+- Batch prediction submit: **3 requests/minute per user** (stricter; each batch may include up to 50 predictions)
+- Batch leaderboard lookup: 10 requests/minute per user
+- Auth, chat, admin round creation, and oracle resolve endpoints have tailored policies
+- Rate-limit hits are recorded for the admin metrics dashboard (`GET /api/admin/metrics/rate-limits`)
+
+#### **Route Authorization Registry (`src/security/route-auth.registry.ts`)**
+- Canonical list of API routes and required auth levels (`public`, `authenticated`, `admin`, `oracle`)
+- `src/tests/security.spec.ts` and `src/tests/route-auth.registry.spec.ts` fail CI when the registry drifts from implemented routes
+- Role middleware (`requireAdmin`, `requireOracle`, `authenticateUser`) is built on a shared `requireRole` helper in `auth.middleware.ts`
 
 ---
 
@@ -875,7 +884,8 @@ Current test coverage includes:
 | `npm run ci` | Run lint, build, unit coverage, and integration tests |
 | `npm run prisma:generate` | Generate Prisma client |
 | `npm run prisma:migrate` | Run database migrations |
-| `npm run docs:openapi` | Generate OpenAPI JSON spec |
+| `npm run docs:openapi` | Generate OpenAPI JSON spec to `docs/openapi.json` |
+| `npm run docs:verify` | Regenerate OpenAPI and verify required paths are documented (CI gate) |
 | `npm run docs:postman` | Export Postman collection |
 | `npm run scorecard` | Run the production-readiness scorecard (see [#197](https://github.com/TevaLabs/Xelma-Backend/issues/197)) |
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -10,25 +10,626 @@
       "url": "http://localhost:3000"
     }
   ],
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "Paste a JWT like: Bearer <token>"
+      }
+    },
+    "schemas": {
+      "ErrorResponse": {
+        "type": "object",
+        "description": "Standard error response returned by all API endpoints on failure.",
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "Error class name (e.g. ValidationError, AuthenticationError, NotFoundError)",
+            "example": "ValidationError"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable description of the error",
+            "example": "walletAddress is required"
+          },
+          "code": {
+            "type": "string",
+            "description": "Machine-readable error code for programmatic handling",
+            "example": "VALIDATION_ERROR"
+          },
+          "details": {
+            "type": "array",
+            "description": "Field-level validation details (present on validation errors only)",
+            "items": {
+              "type": "object",
+              "properties": {
+                "field": {
+                  "type": "string",
+                  "example": "walletAddress"
+                },
+                "message": {
+                  "type": "string",
+                  "example": "walletAddress is required"
+                }
+              },
+              "required": [
+                "field",
+                "message"
+              ]
+            }
+          }
+        },
+        "required": [
+          "error",
+          "message",
+          "code"
+        ]
+      },
+      "RateLimitResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ],
+        "example": {
+          "error": "AppError",
+          "message": "Too many requests from this IP, please try again after 15 minutes",
+          "code": "RATE_LIMIT_EXCEEDED"
+        }
+      },
+      "AuthChallengeRequest": {
+        "type": "object",
+        "properties": {
+          "walletAddress": {
+            "type": "string",
+            "description": "Stellar wallet public key (G...)",
+            "example": "GBRPYHIL2C2V3F5YQZ4H6J7K8L9M0N1O2P3Q4R5S6T7U8V9W0X1Y2Z3A4B"
+          }
+        },
+        "required": [
+          "walletAddress"
+        ],
+        "additionalProperties": false
+      },
+      "AuthChallengeResponse": {
+        "type": "object",
+        "properties": {
+          "challenge": {
+            "type": "string",
+            "example": "random-challenge-string"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "challenge",
+          "expiresAt"
+        ],
+        "additionalProperties": false
+      },
+      "AuthConnectRequest": {
+        "type": "object",
+        "properties": {
+          "walletAddress": {
+            "type": "string",
+            "description": "Stellar wallet public key (G...)"
+          },
+          "challenge": {
+            "type": "string",
+            "description": "Challenge previously returned from /challenge"
+          },
+          "signature": {
+            "type": "string",
+            "description": "Signature over the challenge"
+          }
+        },
+        "required": [
+          "walletAddress",
+          "challenge",
+          "signature"
+        ],
+        "additionalProperties": false
+      },
+      "AuthConnectResponse": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string",
+            "description": "JWT access token"
+          },
+          "user": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "walletAddress": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "lastLoginAt": {
+                "type": "string",
+                "format": "date-time"
+              }
+            },
+            "required": [
+              "id",
+              "walletAddress",
+              "createdAt",
+              "lastLoginAt"
+            ],
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "token",
+          "user"
+        ],
+        "additionalProperties": false
+      },
+      "LeaderboardResponse": {
+        "type": "object",
+        "properties": {
+          "leaderboard": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "userPosition": {
+            "type": "object",
+            "nullable": true
+          },
+          "totalUsers": {
+            "type": "number"
+          },
+          "lastUpdated": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "leaderboard",
+          "totalUsers",
+          "lastUpdated"
+        ],
+        "additionalProperties": true
+      },
+      "RoundResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "UP_DOWN",
+              "LEGENDS"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "PENDING",
+              "ACTIVE",
+              "LOCKED",
+              "RESOLVED",
+              "CANCELLED"
+            ]
+          },
+          "startPrice": {
+            "type": "string",
+            "description": "Decimal string"
+          },
+          "endPrice": {
+            "type": "string",
+            "nullable": true,
+            "description": "Decimal string (set on resolution)"
+          },
+          "startTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "resolvedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Timestamp of resolution"
+          },
+          "poolUp": {
+            "type": "string",
+            "description": "Decimal string"
+          },
+          "poolDown": {
+            "type": "string",
+            "description": "Decimal string"
+          },
+          "sorobanRoundId": {
+            "type": "string",
+            "nullable": true
+          },
+          "priceRanges": {
+            "type": "array",
+            "nullable": true,
+            "description": "LEGENDS mode only. Range matching uses inclusive lower bounds and exclusive upper bounds, except the final range upper bound is inclusive.",
+            "items": {
+              "$ref": "#/components/schemas/LegendsPriceRange"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "mode",
+          "status",
+          "startPrice",
+          "startTime",
+          "endTime"
+        ],
+        "additionalProperties": true
+      },
+      "LegendsPriceRange": {
+        "type": "object",
+        "description": "Selectable LEGENDS range. Pool tracks total amount staked in the range.",
+        "properties": {
+          "min": {
+            "type": "number",
+            "description": "Inclusive lower bound of the range"
+          },
+          "max": {
+            "type": "number",
+            "description": "Exclusive upper bound of the range (inclusive only for the final configured range)"
+          },
+          "pool": {
+            "type": "number",
+            "description": "Current total staked amount in this range",
+            "example": 125.5
+          }
+        },
+        "required": [
+          "min",
+          "max"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
   "tags": [
-    { "name": "auth", "description": "Wallet authentication and JWT issuance" },
-    { "name": "leaderboard", "description": "Leaderboard and rankings" },
-    { "name": "rounds", "description": "Round management and resolution" },
-    { "name": "predictions", "description": "Prediction placement and queries" },
-    { "name": "education", "description": "Educational content" },
-    { "name": "user", "description": "User profile & balance (planned)" }
+    {
+      "name": "auth",
+      "description": "Wallet authentication and JWT issuance"
+    },
+    {
+      "name": "user",
+      "description": "User profile, balance, stats, and transactions"
+    },
+    {
+      "name": "leaderboard",
+      "description": "Leaderboard and rankings"
+    },
+    {
+      "name": "rounds",
+      "description": "Round management and resolution"
+    },
+    {
+      "name": "predictions",
+      "description": "Prediction placement and queries"
+    },
+    {
+      "name": "education",
+      "description": "Educational guides and tips"
+    },
+    {
+      "name": "chat",
+      "description": "Global chat messaging"
+    },
+    {
+      "name": "notifications",
+      "description": "User notifications management"
+    },
+    {
+      "name": "Admin",
+      "description": "Administrative and operational endpoints"
+    }
   ],
   "paths": {
+    "/api/admin/cors-diagnostics": {
+      "get": {
+        "summary": "Resolved CORS origin allowlist for HTTP and Socket.IO",
+        "description": "Returns the effective CORS configuration that this process is\nenforcing right now, so operators can debug origin-mismatch\nerrors against frontends without needing shell access.\nAdmin only. Exposes only the resolved allowlist plus the\nconfig-shaping env vars (`NODE_ENV`, `CLIENT_URL`,\n`ALLOWED_ORIGINS`). No secrets are returned, and an optional\n`?origin=` query parameter reports whether that origin would\nbe accepted.\n",
+        "tags": [
+          "Admin"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "origin",
+            "schema": {
+              "type": "string"
+            },
+            "description": "An origin to test against the resolved allowlist."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resolved CORS configuration"
+          }
+        }
+      }
+    },
+    "/api/admin/dead-letter": {
+      "get": {
+        "summary": "List failed notification/event dispatches",
+        "description": "Returns the dead-letter queue contents, newest first. Admin only.\nUse `?status=` and `?channel=` to filter; defaults to all rows.\n",
+        "tags": [
+          "Admin"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/api/admin/dead-letter/retry-all": {
+      "post": {
+        "summary": "Replay every pending/retrying dispatch in the DLQ",
+        "description": "Admin only. Returns a counts summary.",
+        "tags": [
+          "Admin"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/api/admin/dead-letter/{id}/retry": {
+      "post": {
+        "summary": "Replay a single DLQ entry",
+        "tags": [
+          "Admin"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/api/admin/metrics/rate-limits": {
+      "get": {
+        "summary": "Rate-limit activity summary",
+        "description": "Returns statistics about rate-limit hits and operator-facing suspicious activity\nfor auth, prediction, and chat endpoints. Admin only.\n",
+        "tags": [
+          "Admin"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "default": 10
+            },
+            "description": "Number of records to return for each category"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Rate-limit metrics summary",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "topEndpoints": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "hits": {
+                            "type": "integer"
+                          }
+                        }
+                      }
+                    },
+                    "topAbusers": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "hits": {
+                            "type": "integer"
+                          }
+                        }
+                      }
+                    },
+                    "recentEvents": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          },
+                          "ip": {
+                            "type": "string"
+                          },
+                          "userId": {
+                            "type": "string"
+                          },
+                          "timestamp": {
+                            "type": "string",
+                            "format": "date-time"
+                          }
+                        }
+                      }
+                    },
+                    "suspiciousActivity": {
+                      "type": "object",
+                      "description": "Auth, prediction, and chat abuse heuristics for operators",
+                      "properties": {
+                        "lookbackHours": {
+                          "type": "integer"
+                        },
+                        "hitThreshold": {
+                          "type": "integer"
+                        },
+                        "byCategory": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "category": {
+                                "type": "string",
+                                "enum": [
+                                  "auth",
+                                  "prediction",
+                                  "chat"
+                                ]
+                              },
+                              "hits": {
+                                "type": "integer"
+                              },
+                              "uniqueKeys": {
+                                "type": "integer"
+                              }
+                            }
+                          }
+                        },
+                        "flaggedActors": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "hits": {
+                                "type": "integer"
+                              },
+                              "category": {
+                                "type": "string"
+                              },
+                              "userId": {
+                                "type": "string"
+                              },
+                              "ip": {
+                                "type": "string"
+                              },
+                              "lastSeenAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/api/admin/metrics/rate-limits/clear": {
+      "post": {
+        "summary": "Clear old rate-limit metrics",
+        "description": "Deletes rate-limit records older than a specific number of days. Admin only.",
+        "tags": [
+          "Admin"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "days",
+            "schema": {
+              "type": "integer",
+              "default": 7
+            },
+            "description": "Clear records older than this many days"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Number of records deleted"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
     "/api/auth/challenge": {
       "post": {
-        "tags": ["auth"],
         "summary": "Request a wallet authentication challenge",
-        "description": "Step 1 of wallet authentication. Returns a one-time challenge string for the wallet to sign.\n\nRate limit: 10 requests per 15 minutes per IP. On limit, responds with 429.",
+        "description": "Step 1 of wallet authentication. Returns a one-time challenge string for the wallet to sign.\\n\nRate limit: **10 requests per 15 minutes per IP**. On limit, responds with **429**.\n",
+        "tags": [
+          "auth"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/AuthChallengeRequest" },
+              "schema": {
+                "$ref": "#/components/schemas/AuthChallengeRequest"
+              },
               "example": {
                 "walletAddress": "GB3JDWCQWJ5VQJ3H6E6GQGZVFKU4ZQXGJ6S4Q2W7S6ZJ5R2YQH2B7ZQX"
               }
@@ -40,7 +641,9 @@
             "description": "Challenge created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/AuthChallengeResponse" },
+                "schema": {
+                  "$ref": "#/components/schemas/AuthChallengeResponse"
+                },
                 "example": {
                   "challenge": "random-challenge-string",
                   "expiresAt": "2026-01-29T00:00:00.000Z"
@@ -73,7 +676,13 @@
             "description": "Too many requests",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/RateLimitResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitResponse"
+                },
+                "example": {
+                  "error": "Too Many Requests",
+                  "message": "Too many challenge requests from this IP, please try again after 15 minutes"
+                }
               }
             }
           },
@@ -88,19 +697,29 @@
               }
             }
           }
-        }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "source": "curl -X POST \"$API_BASE_URL/api/auth/challenge\" \\\\\n  -H \"Content-Type: application/json\" \\\\\n  -d '{\"walletAddress\":\"GB3JDWCQWJ5VQJ3H6E6GQGZVFKU4ZQXGJ6S4Q2W7S6ZJ5R2YQH2B7ZQX\"}'\n"
+          }
+        ]
       }
     },
     "/api/auth/connect": {
       "post": {
-        "tags": ["auth"],
         "summary": "Verify signature and authenticate wallet",
-        "description": "Step 2 of wallet authentication. Verifies the signature for the challenge and returns a JWT.\n\nRate limit: 5 requests per 15 minutes per IP. On limit, responds with 429.",
+        "description": "Step 2 of wallet authentication. Verifies the signature for the challenge and returns a JWT.\\n\nRate limit: **5 requests per 15 minutes per IP**. On limit, responds with **429**.\n",
+        "tags": [
+          "auth"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/AuthConnectRequest" },
+              "schema": {
+                "$ref": "#/components/schemas/AuthConnectRequest"
+              },
               "example": {
                 "walletAddress": "GB3JDWCQWJ5VQJ3H6E6GQGZVFKU4ZQXGJ6S4Q2W7S6ZJ5R2YQH2B7ZQX",
                 "challenge": "random-challenge-string",
@@ -114,7 +733,9 @@
             "description": "Authenticated",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/AuthConnectResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/AuthConnectResponse"
+                }
               }
             }
           },
@@ -135,7 +756,10 @@
               "application/json": {
                 "examples": {
                   "invalidSignature": {
-                    "value": { "error": "Authentication Error", "message": "Invalid signature" }
+                    "value": {
+                      "error": "Authentication Error",
+                      "message": "Invalid signature"
+                    }
                   },
                   "expiredChallenge": {
                     "value": {
@@ -151,7 +775,13 @@
             "description": "Too many requests",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/RateLimitResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitResponse"
+                },
+                "example": {
+                  "error": "Too Many Requests",
+                  "message": "Too many authentication attempts from this IP, please try again after 15 minutes"
+                }
               }
             }
           },
@@ -159,7 +789,150 @@
             "description": "Internal server error",
             "content": {
               "application/json": {
-                "example": { "error": "Internal Server Error", "message": "Failed to authenticate wallet" }
+                "example": {
+                  "error": "Internal Server Error",
+                  "message": "Failed to authenticate wallet"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "source": "curl -X POST \"$API_BASE_URL/api/auth/connect\" \\\\\n  -H \"Content-Type: application/json\" \\\\\n  -d '{\"walletAddress\":\"GB3JDWCQWJ5VQJ3H6E6GQGZVFKU4ZQXGJ6S4Q2W7S6ZJ5R2YQH2B7ZQX\",\"challenge\":\"random-challenge-string\",\"signature\":\"base64-or-hex-signature\"}'\n"
+          }
+        ]
+      }
+    },
+    "/api/chat/send": {
+      "post": {
+        "tags": [
+          "Chat"
+        ],
+        "summary": "Send a chat message",
+        "description": "Authenticated users only. Rate limit: **5 messages per minute per user**. On limit, responds with **429**.\n",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "content"
+                ],
+                "properties": {
+                  "content": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Message created"
+          },
+          "429": {
+            "description": "Too many messages",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/education/guides": {
+      "get": {
+        "summary": "Get educational guides",
+        "description": "Returns a structured list of static educational guides grouped by category.",
+        "tags": [
+          "education"
+        ],
+        "responses": {
+          "200": {
+            "description": "Education guides",
+            "content": {
+              "application/json": {
+                "example": {
+                  "guides": [],
+                  "categories": {
+                    "volatility": [],
+                    "stellar": [],
+                    "oracles": []
+                  },
+                  "total": 0
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": "Internal Server Error",
+                  "message": "Failed to fetch education guides"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "source": "curl -X GET \"$API_BASE_URL/api/education/guides\"\n"
+          }
+        ]
+      }
+    },
+    "/errors": {
+      "get": {
+        "summary": "Backend error code catalog (#196)",
+        "description": "Returns the canonical list of error codes the API can emit, along\nwith the HTTP status, the AppError subclass, and a short\nhuman-readable description for each. Use this to build client-side\nerror-handling switches and to drive the public docs.\n",
+        "tags": [
+          "Meta"
+        ],
+        "responses": {
+          "200": {
+            "description": "Catalog of error codes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "entries": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "integer"
+                          },
+                          "errorClass": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
               }
             }
           }
@@ -168,20 +941,31 @@
     },
     "/api/leaderboard": {
       "get": {
-        "tags": ["leaderboard"],
         "summary": "Get the global leaderboard",
-        "description": "Returns the global leaderboard. Bearer authentication is optional; if provided, the API may include the requesting user's position.\n\nQuery params support pagination.",
+        "description": "Returns the global leaderboard. Bearer authentication is **optional**; if provided, the API may include the requesting user's position.\\n\nQuery params support pagination.\n",
+        "tags": [
+          "leaderboard"
+        ],
         "parameters": [
           {
             "in": "query",
             "name": "limit",
-            "schema": { "type": "integer", "minimum": 1, "maximum": 500, "default": 100 },
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 500,
+              "default": 100
+            },
             "description": "Max number of entries to return (max 500)"
           },
           {
             "in": "query",
             "name": "offset",
-            "schema": { "type": "integer", "minimum": 0, "default": 0 },
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            },
             "description": "Pagination offset"
           }
         ],
@@ -190,7 +974,9 @@
             "description": "Leaderboard payload",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LeaderboardResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/LeaderboardResponse"
+                }
               }
             }
           },
@@ -198,19 +984,368 @@
             "description": "Internal server error",
             "content": {
               "application/json": {
-                "example": { "error": "Internal Server Error", "message": "Failed to fetch leaderboard" }
+                "example": {
+                  "error": "Internal Server Error",
+                  "message": "Failed to fetch leaderboard"
+                }
               }
             }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "source": "curl -X GET \"$API_BASE_URL/api/leaderboard?limit=100&offset=0\"\n"
+          }
+        ]
+      }
+    },
+    "/api/leaderboard/batch": {
+      "post": {
+        "summary": "Get leaderboard positions for multiple users",
+        "description": "Retrieve leaderboard positions and stats for multiple users in a single request.\nEach user lookup is processed independently. Partial success is supported.\nMaximum 100 user IDs per request.\n",
+        "tags": [
+          "leaderboard"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "maxItems": 100,
+                    "description": "Array of user IDs to query"
+                  }
+                },
+                "required": [
+                  "userIds"
+                ]
+              },
+              "example": {
+                "userIds": [
+                  "user-id-1",
+                  "user-id-2",
+                  "user-id-3"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Batch user positions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "true if at least one query succeeded"
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/BatchUserPositionResult"
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "success": true,
+                  "results": [
+                    {
+                      "userId": "user-id-1",
+                      "position": {
+                        "rank": 15,
+                        "userId": "user-id-1",
+                        "walletAddress": "GBRPY...4B",
+                        "totalEarnings": 125.5,
+                        "totalPredictions": 42,
+                        "accuracy": 73.81,
+                        "modeStats": {
+                          "upDown": {
+                            "wins": 20,
+                            "losses": 10,
+                            "earnings": 85.25,
+                            "accuracy": 66.67
+                          },
+                          "legends": {
+                            "wins": 12,
+                            "losses": 8,
+                            "earnings": 40.25,
+                            "accuracy": 60
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "userId": "user-id-2",
+                      "error": "User not found"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "emptyUserIds": {
+                    "value": {
+                      "error": "At least one user ID is required"
+                    }
+                  },
+                  "tooManyUserIds": {
+                    "value": {
+                      "error": "Maximum 100 user IDs per query"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": "No token provided"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": "Failed to fetch batch user positions"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "source": "curl -X POST \"$API_BASE_URL/api/leaderboard/batch\" \\\\\n  -H \"Content-Type: application/json\" \\\\\n  -H \"Authorization: Bearer $TOKEN\" \\\\\n  -d '{\"userIds\":[\"user-id-1\",\"user-id-2\"]}'\n"
+          }
+        ]
+      }
+    },
+    "/metrics": {
+      "get": {
+        "summary": "Prometheus metrics",
+        "description": "Returns all application and process metrics in Prometheus text format. Scrape this endpoint with a Prometheus instance.\n",
+        "tags": [
+          "Observability"
+        ],
+        "responses": {
+          "200": {
+            "description": "Prometheus text exposition format",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/predictions/submit": {
+      "post": {
+        "tags": [
+          "Predictions"
+        ],
+        "summary": "Submit a prediction",
+        "description": "Submit a prediction for a round. Supports idempotency via Idempotency-Key header for safe retries.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique key for idempotent request handling (UUID recommended)"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "roundId",
+                  "amount",
+                  "side"
+                ],
+                "properties": {
+                  "roundId": {
+                    "type": "string"
+                  },
+                  "amount": {
+                    "type": "number"
+                  },
+                  "side": {
+                    "type": "string",
+                    "enum": [
+                      "up",
+                      "down"
+                    ]
+                  },
+                  "priceRange": {
+                    "type": "object",
+                    "properties": {
+                      "min": {
+                        "type": "number"
+                      },
+                      "max": {
+                        "type": "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Prediction submitted"
+          }
+        }
+      }
+    },
+    "/api/predictions/batch-submit": {
+      "post": {
+        "tags": [
+          "Predictions"
+        ],
+        "summary": "Submit multiple predictions at once",
+        "description": "Batch submit up to 50 predictions. Rate limit: **3 batch requests per minute per user** (stricter than single submit). On limit, responds with **429**.\n",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "predictions"
+                ],
+                "properties": {
+                  "predictions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "roundId",
+                        "amount"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Predictions processed"
+          },
+          "429": {
+            "description": "Too many batch requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/predictions/user": {
+      "get": {
+        "tags": [
+          "Predictions"
+        ],
+        "summary": "Get user predictions",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of predictions"
+          }
+        }
+      }
+    },
+    "/api/predictions/round/{roundId}": {
+      "get": {
+        "tags": [
+          "Predictions"
+        ],
+        "summary": "Get predictions for a round",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "roundId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of predictions"
           }
         }
       }
     },
     "/api/rounds/start": {
       "post": {
-        "tags": ["rounds"],
         "summary": "Start a new prediction round",
         "description": "Admin-only. Starts a new round for a given mode, start price, and duration.",
-        "security": [{ "bearerAuth": [] }],
+        "tags": [
+          "rounds"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -218,81 +1353,260 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "mode": { "type": "integer", "enum": [0, 1], "description": "0 (UP_DOWN) or 1 (LEGENDS)" },
-                  "startPrice": { "type": "number", "description": "Starting price (must be > 0)" },
-                  "duration": { "type": "integer", "description": "Duration in seconds (must be > 0)" }
+                  "mode": {
+                    "type": "integer",
+                    "description": "0 (UP_DOWN) or 1 (LEGENDS)",
+                    "enum": [
+                      0,
+                      1
+                    ]
+                  },
+                  "startPrice": {
+                    "type": "number",
+                    "description": "Starting price (must be > 0)"
+                  },
+                  "duration": {
+                    "type": "integer",
+                    "description": "Duration in seconds (must be > 0)"
+                  },
+                  "priceRanges": {
+                    "type": "array",
+                    "description": "Optional LEGENDS-only custom ranges; if omitted, default ranges are generated from startPrice.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "min": {
+                          "type": "number"
+                        },
+                        "max": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "min",
+                        "max"
+                      ]
+                    }
+                  }
                 },
-                "required": ["mode", "startPrice", "duration"]
+                "required": [
+                  "mode",
+                  "startPrice",
+                  "duration"
+                ]
+              },
+              "example": {
+                "mode": 1,
+                "startPrice": 0.1234,
+                "duration": 300,
+                "priceRanges": [
+                  {
+                    "min": 0.1,
+                    "max": 0.12
+                  },
+                  {
+                    "min": 0.12,
+                    "max": 0.14
+                  },
+                  {
+                    "min": 0.14,
+                    "max": 0.16
+                  }
+                ]
               }
             }
           }
         },
         "responses": {
-          "200": { "description": "Round started" },
-          "400": { "description": "Validation error" },
-          "401": { "description": "Unauthorized" },
-          "403": { "description": "Forbidden (admin role required)" },
-          "500": { "description": "Internal server error" }
-        }
+          "200": {
+            "description": "Round started",
+            "content": {
+              "application/json": {
+                "example": {
+                  "success": true,
+                  "round": {
+                    "id": "round-id",
+                    "mode": "UP_DOWN",
+                    "status": "ACTIVE",
+                    "startTime": "2026-01-29T00:00:00.000Z",
+                    "endTime": "2026-01-29T00:05:00.000Z",
+                    "startPrice": 0.1234,
+                    "sorobanRoundId": "1",
+                    "priceRanges": []
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "$ref": "#/components/schemas/ErrorResponse"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized (missing/invalid token)",
+            "content": {
+              "application/json": {
+                "$ref": "#/components/schemas/ErrorResponse"
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden (admin role required)",
+            "content": {
+              "application/json": {
+                "$ref": "#/components/schemas/ErrorResponse"
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict - active round already exists",
+            "content": {
+              "application/json": {
+                "$ref": "#/components/schemas/ErrorResponse"
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "$ref": "#/components/schemas/RateLimitResponse"
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "$ref": "#/components/schemas/ErrorResponse"
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "source": "curl -X POST \"$API_BASE_URL/api/rounds/start\" \\\\\n  -H \"Content-Type: application/json\" \\\\\n  -H \"Authorization: Bearer $TOKEN\" \\\\\n  -d '{\"mode\":0,\"startPrice\":0.1234,\"duration\":300}'\n"
+          }
+        ]
       }
     },
     "/api/rounds/{id}": {
       "get": {
-        "tags": ["rounds"],
         "summary": "Get a round by ID",
+        "tags": [
+          "rounds"
+        ],
         "parameters": [
-          { "in": "path", "name": "id", "required": true, "schema": { "type": "string" }, "description": "Round ID" }
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Round ID"
+          }
         ],
         "responses": {
-          "200": { "description": "Round found" },
-          "404": { "description": "Round not found" },
-          "500": { "description": "Internal server error" }
-        }
-      }
-    },
-    "/api/rounds/active": {
-      "get": {
-        "tags": ["rounds"],
-        "summary": "Get active rounds",
-        "responses": { "200": { "description": "Active rounds" }, "500": { "description": "Internal server error" } }
-      }
-    },
-    "/api/rounds/{id}/resolve": {
-      "post": {
-        "tags": ["rounds"],
-        "summary": "Resolve a round with the final price",
-        "description": "Oracle-only (or Admin). Resolves the round and computes winners.",
-        "security": [{ "bearerAuth": [] }],
-        "parameters": [
-          { "in": "path", "name": "id", "required": true, "schema": { "type": "string" }, "description": "Round ID" }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": { "finalPrice": { "type": "number", "description": "Final price (must be > 0)" } },
-                "required": ["finalPrice"]
+          "200": {
+            "description": "Round found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "success": true,
+                  "round": {}
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Round not found",
+            "content": {
+              "application/json": {
+                "$ref": "#/components/schemas/ErrorResponse"
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "$ref": "#/components/schemas/ErrorResponse"
               }
             }
           }
         },
-        "responses": {
-          "200": { "description": "Round resolved" },
-          "400": { "description": "Validation error" },
-          "401": { "description": "Unauthorized" },
-          "403": { "description": "Forbidden (oracle/admin required)" },
-          "500": { "description": "Internal server error" }
-        }
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "source": "curl -X GET \"$API_BASE_URL/api/rounds/round-id\"\n"
+          }
+        ]
       }
     },
-    "/api/predictions/submit": {
+    "/api/rounds/active": {
+      "get": {
+        "summary": "Get active rounds",
+        "tags": [
+          "rounds"
+        ],
+        "responses": {
+          "200": {
+            "description": "Active rounds",
+            "content": {
+              "application/json": {
+                "example": {
+                  "success": true,
+                  "rounds": []
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "$ref": "#/components/schemas/ErrorResponse"
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "source": "curl -X GET \"$API_BASE_URL/api/rounds/active\"\n"
+          }
+        ]
+      }
+    },
+    "/api/rounds/{id}/resolve": {
       "post": {
-        "tags": ["predictions"],
-        "summary": "Submit a prediction for a round",
-        "description": "Authenticated users only.",
-        "security": [{ "bearerAuth": [] }],
+        "summary": "Resolve a round with the final price",
+        "description": "Oracle-only (or Admin). Resolves the round and computes winners. LEGENDS uses inclusive-lower/exclusive-upper range matching, with final range upper-bound inclusive.",
+        "tags": [
+          "rounds"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Round ID"
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -300,141 +1614,90 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "roundId": { "type": "string" },
-                  "userId": { "type": "string" },
-                  "amount": { "type": "number" },
-                  "side": { "type": "string" },
-                  "priceRange": { "type": "string" }
+                  "finalPrice": {
+                    "type": "number",
+                    "description": "Final price (must be > 0)"
+                  }
                 },
-                "required": ["roundId", "userId", "amount"]
+                "required": [
+                  "finalPrice"
+                ]
+              },
+              "example": {
+                "finalPrice": 0.2345
               }
             }
           }
         },
         "responses": {
-          "200": { "description": "Prediction submitted" },
-          "400": { "description": "Validation error" },
-          "401": { "description": "Unauthorized" },
-          "500": { "description": "Internal server error" }
-        }
-      }
-    },
-    "/api/predictions/user/{userId}": {
-      "get": {
-        "tags": ["predictions"],
-        "summary": "Get all predictions for a user",
-        "parameters": [
-          { "in": "path", "name": "userId", "required": true, "schema": { "type": "string" }, "description": "User ID" }
-        ],
-        "responses": { "200": { "description": "Predictions list" }, "500": { "description": "Internal server error" } }
-      }
-    },
-    "/api/predictions/round/{roundId}": {
-      "get": {
-        "tags": ["predictions"],
-        "summary": "Get all predictions for a round",
-        "parameters": [
-          { "in": "path", "name": "roundId", "required": true, "schema": { "type": "string" }, "description": "Round ID" }
-        ],
-        "responses": { "200": { "description": "Predictions list" }, "500": { "description": "Internal server error" } }
-      }
-    },
-    "/api/education/guides": {
-      "get": {
-        "tags": ["education"],
-        "summary": "Get educational guides",
-        "description": "Returns a structured list of static educational guides grouped by category.",
-        "responses": { "200": { "description": "Education guides" }, "500": { "description": "Internal server error" } }
-      }
-    }
-  },
-  "components": {
-    "securitySchemes": {
-      "bearerAuth": {
-        "type": "http",
-        "scheme": "bearer",
-        "bearerFormat": "JWT",
-        "description": "Paste a JWT like: Bearer <token>"
-      }
-    },
-    "schemas": {
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "error": { "type": "string" },
-          "message": { "type": "string" }
-        },
-        "required": ["error"],
-        "additionalProperties": true
-      },
-      "RateLimitResponse": {
-        "allOf": [{ "$ref": "#/components/schemas/ErrorResponse" }],
-        "example": {
-          "error": "Too Many Requests",
-          "message": "Too many requests from this IP, please try again after 15 minutes"
-        }
-      },
-      "AuthChallengeRequest": {
-        "type": "object",
-        "properties": {
-          "walletAddress": {
-            "type": "string",
-            "description": "Stellar wallet public key (G...)"
+          "200": {
+            "description": "Round resolved",
+            "content": {
+              "application/json": {
+                "example": {
+                  "success": true,
+                  "round": {
+                    "id": "round-id",
+                    "status": "RESOLVED",
+                    "startPrice": 0.1234,
+                    "endPrice": 0.2345,
+                    "resolvedAt": "2026-01-29T00:10:00.000Z",
+                    "predictions": 10,
+                    "winners": 4,
+                    "legendsPayoutRule": "winner payout = stake + (stake / winningPool) * losingPool"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "$ref": "#/components/schemas/ErrorResponse"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "$ref": "#/components/schemas/ErrorResponse"
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden (oracle/admin required)",
+            "content": {
+              "application/json": {
+                "$ref": "#/components/schemas/ErrorResponse"
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "$ref": "#/components/schemas/RateLimitResponse"
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "$ref": "#/components/schemas/ErrorResponse"
+              }
+            }
           }
         },
-        "required": ["walletAddress"],
-        "additionalProperties": false
-      },
-      "AuthChallengeResponse": {
-        "type": "object",
-        "properties": {
-          "challenge": { "type": "string" },
-          "expiresAt": { "type": "string", "format": "date-time" }
-        },
-        "required": ["challenge", "expiresAt"],
-        "additionalProperties": false
-      },
-      "AuthConnectRequest": {
-        "type": "object",
-        "properties": {
-          "walletAddress": { "type": "string" },
-          "challenge": { "type": "string" },
-          "signature": { "type": "string" }
-        },
-        "required": ["walletAddress", "challenge", "signature"],
-        "additionalProperties": false
-      },
-      "AuthConnectResponse": {
-        "type": "object",
-        "properties": {
-          "token": { "type": "string" },
-          "user": {
-            "type": "object",
-            "properties": {
-              "id": { "type": "string" },
-              "walletAddress": { "type": "string" },
-              "createdAt": { "type": "string", "format": "date-time" },
-              "lastLoginAt": { "type": "string", "format": "date-time" }
-            },
-            "required": ["id", "walletAddress", "createdAt", "lastLoginAt"],
-            "additionalProperties": true
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "source": "curl -X POST \"$API_BASE_URL/api/rounds/round-id/resolve\" \\\\\n  -H \"Content-Type: application/json\" \\\\\n  -H \"Authorization: Bearer $TOKEN\" \\\\\n  -d '{\"finalPrice\":0.2345}'\n"
           }
-        },
-        "required": ["token", "user"],
-        "additionalProperties": false
-      },
-      "LeaderboardResponse": {
-        "type": "object",
-        "properties": {
-          "leaderboard": { "type": "array", "items": { "type": "object" } },
-          "userPosition": { "type": "object", "nullable": true },
-          "totalUsers": { "type": "number" },
-          "lastUpdated": { "type": "string" }
-        },
-        "required": ["leaderboard", "totalUsers", "lastUpdated"],
-        "additionalProperties": true
+        ]
       }
     }
   }
 }
-

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
       "postinstall": "npm run build",
       "start:render-parity": "NODE_ENV=production node dist/index.js",
       "docs:openapi": "node dist/scripts/generate-openapi.js",
+      "docs:verify": "node scripts/verify-openapi-sync.js",
       "docs:postman": "node dist/scripts/export-postman.js",
       "prisma:generate": "prisma generate",
       "prisma:migrate": "prisma migrate dev"

--- a/scripts/verify-openapi-sync.js
+++ b/scripts/verify-openapi-sync.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+/**
+ * Verifies that docs/openapi.json matches the generated spec from route annotations.
+ * CI runs this after `npm run build` and `npm run docs:openapi`.
+ */
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+const ROOT = path.resolve(__dirname, "..");
+const SPEC_PATH = path.join(ROOT, "docs", "openapi.json");
+
+const REQUIRED_PATHS = [
+  "/api/auth/challenge",
+  "/api/auth/connect",
+  "/api/predictions/submit",
+  "/api/predictions/batch-submit",
+  "/api/chat/send",
+  "/api/admin/metrics/rate-limits",
+  "/api/rounds/start",
+];
+
+function main() {
+  if (!fs.existsSync(path.join(ROOT, "dist", "scripts", "generate-openapi.js"))) {
+    console.error("Missing dist/scripts/generate-openapi.js — run `npm run build` first.");
+    process.exit(1);
+  }
+
+  execSync("npm run docs:openapi", { cwd: ROOT, stdio: "inherit" });
+
+  if (!fs.existsSync(SPEC_PATH)) {
+    console.error(`OpenAPI spec was not written to ${SPEC_PATH}`);
+    process.exit(1);
+  }
+
+  const spec = JSON.parse(fs.readFileSync(SPEC_PATH, "utf8"));
+  const paths = spec.paths ?? {};
+  const missing = REQUIRED_PATHS.filter((p) => !paths[p]);
+
+  if (missing.length > 0) {
+    console.error("Generated OpenAPI spec is missing required paths:");
+    for (const p of missing) {
+      console.error(`  - ${p}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`OpenAPI sync OK (${Object.keys(paths).length} paths, required routes present).`);
+}
+
+main();

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -4,6 +4,7 @@ import { UserRole } from "@prisma/client";
 import { prisma } from "../lib/prisma";
 import logger from "../utils/logger";
 import { AuthRequest, AuthenticatedRequest, JwtPayload } from "../types/auth.types";
+import { ORACLE_ALLOWED_ROLES } from "../security/route-auth.registry";
 
 // Re-export UserRole for backwards compatibility
 export { UserRole };
@@ -20,59 +21,94 @@ declare global {
   }
 }
 
+type ResolvedUser = {
+  id: string;
+  walletAddress: string;
+  role: UserRole;
+};
+
+async function loadUserFromBearerToken(
+  authHeader: string | undefined,
+): Promise<ResolvedUser | null> {
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    return null;
+  }
+
+  const token = authHeader.substring(7);
+  const decoded = verifyToken(token);
+
+  if (!decoded) {
+    return null;
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: decoded.userId },
+    select: {
+      id: true,
+      walletAddress: true,
+      role: true,
+    },
+  });
+
+  return user;
+}
+
+function attachUser(req: Request, user: ResolvedUser): void {
+  req.user = {
+    userId: user.id,
+    walletAddress: user.walletAddress,
+    role: user.role,
+  };
+}
+
+function userHasAnyRole(user: ResolvedUser, allowedRoles: UserRole[]): boolean {
+  return allowedRoles.includes(user.role);
+}
+
+/**
+ * Factory for role-gated middleware. Centralizes JWT verification and DB role lookup
+ * so new routes cannot drift from the route auth registry expectations.
+ */
+export function requireRole(
+  allowedRoles: UserRole[],
+  options?: { forbiddenMessage?: string },
+): (req: Request, res: Response, next: NextFunction) => Promise<void> {
+  const forbiddenMessage =
+    options?.forbiddenMessage ?? "You do not have permission to access this resource";
+
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const requestId = (req as any).requestId;
+    try {
+      const user = await loadUserFromBearerToken(req.headers.authorization);
+
+      if (!user) {
+        const hasHeader = Boolean(req.headers.authorization?.startsWith("Bearer "));
+        res.status(401).json({
+          error: hasHeader ? "Invalid or expired token" : "No token provided",
+        });
+        return;
+      }
+
+      if (!userHasAnyRole(user, allowedRoles)) {
+        res.status(403).json({ error: forbiddenMessage });
+        return;
+      }
+
+      attachUser(req, user);
+      next();
+    } catch (error) {
+      logger.error("Role authentication error:", { error, requestId });
+      res.status(401).json({ error: "Authentication failed" });
+    }
+  };
+}
+
 /**
  * Middleware to authenticate user via JWT token
  */
-export const authenticateUser = async (
-  req: Request,
-  res: Response,
-  next: NextFunction,
-): Promise<void> => {
-  const requestId = (req as any).requestId;
-  try {
-    const authHeader = req.headers.authorization;
-
-    if (!authHeader || !authHeader.startsWith("Bearer ")) {
-      res.status(401).json({ error: "No token provided" });
-      return;
-    }
-
-    const token = authHeader.substring(7); // Remove 'Bearer ' prefix
-    const decoded = verifyToken(token) as any;
-
-    if (!decoded) {
-      res.status(401).json({ error: "Invalid or expired token" });
-      return;
-    }
-
-    // Get user from database to check role
-    const user = await prisma.user.findUnique({
-      where: { id: decoded.userId },
-      select: {
-        id: true,
-        walletAddress: true,
-        role: true,
-      },
-    });
-
-    if (!user) {
-      res.status(401).json({ error: "User not found" });
-      return;
-    }
-
-    // Attach user to request
-    req.user = {
-      userId: user.id,
-      walletAddress: user.walletAddress,
-      role: user.role,
-    };
-
-    next();
-  } catch (error) {
-    logger.error("Authentication error:", { error, requestId });
-    res.status(401).json({ error: "Authentication failed" });
-  }
-};
+export const authenticateUser = requireRole(
+  [UserRole.USER, UserRole.ADMIN, UserRole.ORACLE],
+);
 
 // Alias for backwards compatibility
 export const authenticateToken = authenticateUser;
@@ -87,36 +123,10 @@ export const optionalAuthentication = async (
   next: NextFunction,
 ): Promise<void> => {
   try {
-    const authHeader = req.headers.authorization;
-
-    if (!authHeader || !authHeader.startsWith("Bearer ")) {
-      next();
-      return;
-    }
-
-    const token = authHeader.substring(7);
-    const decoded = verifyToken(token);
-
-    if (!decoded) {
-      next();
-      return;
-    }
-
-    const user = await prisma.user.findUnique({
-      where: { id: decoded.userId },
-      select: {
-        id: true,
-        walletAddress: true,
-        role: true,
-      },
-    });
+    const user = await loadUserFromBearerToken(req.headers.authorization);
 
     if (user) {
-      req.user = {
-        userId: user.id,
-        walletAddress: user.walletAddress,
-        role: user.role,
-      };
+      attachUser(req, user);
     }
 
     next();
@@ -129,105 +139,13 @@ export const optionalAuthentication = async (
 /**
  * Middleware to require admin role
  */
-export const requireAdmin = async (
-  req: Request,
-  res: Response,
-  next: NextFunction,
-): Promise<void> => {
-  const requestId = (req as any).requestId;
-  try {
-    const authHeader = req.headers.authorization;
-
-    if (!authHeader || !authHeader.startsWith("Bearer ")) {
-      res.status(401).json({ error: "No token provided" });
-      return;
-    }
-
-    const token = authHeader.substring(7);
-    const decoded = verifyToken(token);
-
-    if (!decoded) {
-      res.status(401).json({ error: "Invalid or expired token" });
-      return;
-    }
-
-    const user = await prisma.user.findUnique({
-      where: { id: decoded.userId },
-      select: { id: true, walletAddress: true, role: true },
-    });
-
-    if (!user) {
-      res.status(401).json({ error: "User not found" });
-      return;
-    }
-
-    if (user.role !== UserRole.ADMIN) {
-      res.status(403).json({ error: "Admin access required" });
-      return;
-    }
-
-    req.user = {
-      userId: user.id,
-      walletAddress: user.walletAddress,
-      role: user.role,
-    };
-
-    next();
-  } catch (error) {
-    logger.error("Admin authentication error:", { error, requestId });
-    res.status(401).json({ error: "Authentication failed" });
-  }
-};
+export const requireAdmin = requireRole([UserRole.ADMIN], {
+  forbiddenMessage: "Admin access required",
+});
 
 /**
- * Middleware to require oracle role
+ * Middleware to require oracle role (oracle or admin)
  */
-export const requireOracle = async (
-  req: Request,
-  res: Response,
-  next: NextFunction,
-): Promise<void> => {
-  const requestId = (req as any).requestId;
-  try {
-    const authHeader = req.headers.authorization;
-
-    if (!authHeader || !authHeader.startsWith("Bearer ")) {
-      res.status(401).json({ error: "No token provided" });
-      return;
-    }
-
-    const token = authHeader.substring(7);
-    const decoded = verifyToken(token);
-
-    if (!decoded) {
-      res.status(401).json({ error: "Invalid or expired token" });
-      return;
-    }
-
-    const user = await prisma.user.findUnique({
-      where: { id: decoded.userId },
-      select: { id: true, walletAddress: true, role: true },
-    });
-
-    if (!user) {
-      res.status(401).json({ error: "User not found" });
-      return;
-    }
-
-    if (user.role !== UserRole.ORACLE && user.role !== UserRole.ADMIN) {
-      res.status(403).json({ error: "Oracle or Admin access required" });
-      return;
-    }
-
-    req.user = {
-      userId: user.id,
-      walletAddress: user.walletAddress,
-      role: user.role,
-    };
-
-    next();
-  } catch (error) {
-    logger.error("Oracle authentication error:", { error, requestId });
-    res.status(401).json({ error: "Authentication failed" });
-  }
-};
+export const requireOracle = requireRole(ORACLE_ALLOWED_ROLES, {
+  forbiddenMessage: "Oracle or Admin access required",
+});

--- a/src/middleware/metrics.middleware.ts
+++ b/src/middleware/metrics.middleware.ts
@@ -93,6 +93,13 @@ export const circuitBreakerState = new Gauge({
   registers: [metricsRegistry],
 });
 
+export const rateLimitHitsTotal = new Counter({
+  name: 'rate_limit_hits_total',
+  help: 'Total HTTP 429 responses from express-rate-limit handlers',
+  labelNames: ['endpoint', 'category'] as const,
+  registers: [metricsRegistry],
+});
+
 // ---------------------------------------------------------------------------
 // DB / Prisma pool settings (low-cardinality)
 // ---------------------------------------------------------------------------

--- a/src/middleware/rateLimiter.middleware.ts
+++ b/src/middleware/rateLimiter.middleware.ts
@@ -1,6 +1,29 @@
 import rateLimit from 'express-rate-limit';
 import { rateLimitMetricsService } from '../services/rate-limit-metrics.service';
+import { getRateLimitCategory } from '../security/rate-limit-endpoints';
+import { rateLimitHitsTotal } from './metrics.middleware';
 import logger from '../utils/logger';
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/** Documented limits for tests and operator reference */
+export const RATE_LIMIT_POLICIES = {
+  predictionSubmit: { windowMs: 60 * 1000, max: 10, name: 'prediction/submit' },
+  predictionBatchSubmit: {
+    windowMs: parsePositiveInt(process.env.BATCH_PREDICTION_RATE_LIMIT_WINDOW_MS, 60 * 1000),
+    max: parsePositiveInt(process.env.BATCH_PREDICTION_RATE_LIMIT_MAX, 3),
+    name: 'prediction/batch-submit',
+  },
+  leaderboardBatch: {
+    windowMs: parsePositiveInt(process.env.BATCH_LEADERBOARD_RATE_LIMIT_WINDOW_MS, 60 * 1000),
+    max: parsePositiveInt(process.env.BATCH_LEADERBOARD_RATE_LIMIT_MAX, 10),
+    name: 'leaderboard/batch',
+  },
+} as const;
 
 /**
  * Factory function to create rate limiters with consistent configuration
@@ -22,8 +45,10 @@ function createRateLimiter(opts: {
     handler: (req, res) => {
       const key = opts.keyGenerator ? opts.keyGenerator(req) : (req.ip || 'unknown');
       const userId = req.user?.userId;
+      const category = getRateLimitCategory(opts.name);
 
-      // Track the hit in the background
+      rateLimitHitsTotal.inc({ endpoint: opts.name, category });
+
       rateLimitMetricsService.recordHit({
         endpoint: opts.name,
         key: key,
@@ -69,11 +94,35 @@ export const chatMessageRateLimiter = createRateLimiter({
 
 // Prediction submission rate limiter (per user)
 export const predictionRateLimiter = createRateLimiter({
-  windowMs: 60 * 1000,
-  max: 10,
+  windowMs: RATE_LIMIT_POLICIES.predictionSubmit.windowMs,
+  max: RATE_LIMIT_POLICIES.predictionSubmit.max,
   message: 'Too many prediction submissions. Please wait before submitting another.',
   keyGenerator: (req) => req.user?.userId || req.ip || 'unknown',
-  name: 'prediction/submit',
+  name: RATE_LIMIT_POLICIES.predictionSubmit.name,
+});
+
+/**
+ * Stricter limit for batch prediction submission (up to 50 predictions per request).
+ * Tunable via BATCH_PREDICTION_RATE_LIMIT_MAX and BATCH_PREDICTION_RATE_LIMIT_WINDOW_MS.
+ */
+export const batchPredictionRateLimiter = createRateLimiter({
+  windowMs: RATE_LIMIT_POLICIES.predictionBatchSubmit.windowMs,
+  max: RATE_LIMIT_POLICIES.predictionBatchSubmit.max,
+  message:
+    'Too many batch prediction requests. Each batch can include many predictions — please wait before submitting another batch.',
+  keyGenerator: (req) => req.user?.userId || req.ip || 'unknown',
+  name: RATE_LIMIT_POLICIES.predictionBatchSubmit.name,
+});
+
+/**
+ * Rate limit for batch leaderboard lookups (per user).
+ */
+export const batchLeaderboardRateLimiter = createRateLimiter({
+  windowMs: RATE_LIMIT_POLICIES.leaderboardBatch.windowMs,
+  max: RATE_LIMIT_POLICIES.leaderboardBatch.max,
+  message: 'Too many batch leaderboard requests. Please wait before trying again.',
+  keyGenerator: (req) => req.user?.userId || req.ip || 'unknown',
+  name: RATE_LIMIT_POLICIES.leaderboardBatch.name,
 });
 
 // Admin round creation rate limiter (per IP)
@@ -91,4 +140,3 @@ export const oracleResolveRateLimiter = createRateLimiter({
   message: 'Too many resolve requests. Please wait before resolving another round.',
   name: 'oracle/round-resolve',
 });
-

--- a/src/routes/admin-cors-diagnostics.routes.ts
+++ b/src/routes/admin-cors-diagnostics.routes.ts
@@ -7,7 +7,7 @@ const router = Router();
 
 /**
  * @openapi
- * /admin/cors-diagnostics:
+ * /api/admin/cors-diagnostics:
  *   get:
  *     summary: Resolved CORS origin allowlist for HTTP and Socket.IO
  *     description: |

--- a/src/routes/admin-dead-letter.routes.ts
+++ b/src/routes/admin-dead-letter.routes.ts
@@ -57,7 +57,7 @@ function parseInt32(raw: unknown, fallback: number): number {
 
 /**
  * @openapi
- * /admin/dead-letter:
+ * /api/admin/dead-letter:
  *   get:
  *     summary: List failed notification/event dispatches
  *     description: |
@@ -85,7 +85,7 @@ router.get('/', requireAdmin, async (req: Request, res: Response) => {
 
 /**
  * @openapi
- * /admin/dead-letter/retry-all:
+ * /api/admin/dead-letter/retry-all:
  *   post:
  *     summary: Replay every pending/retrying dispatch in the DLQ
  *     description: Admin only. Returns a counts summary.
@@ -110,7 +110,7 @@ router.post('/retry-all', requireAdmin, async (req: Request, res: Response) => {
 
 /**
  * @openapi
- * /admin/dead-letter/{id}/retry:
+ * /api/admin/dead-letter/{id}/retry:
  *   post:
  *     summary: Replay a single DLQ entry
  *     tags:

--- a/src/routes/admin-metrics.routes.ts
+++ b/src/routes/admin-metrics.routes.ts
@@ -7,10 +7,12 @@ const router = Router();
 
 /**
  * @openapi
- * /admin/metrics/rate-limits:
+ * /api/admin/metrics/rate-limits:
  *   get:
  *     summary: Rate-limit activity summary
- *     description: Returns statistics about rate-limit hits and potential abuse patterns. Admin only.
+ *     description: |
+ *       Returns statistics about rate-limit hits and operator-facing suspicious activity
+ *       for auth, prediction, and chat endpoints. Admin only.
  *     tags:
  *       - Admin
  *     security:
@@ -68,6 +70,46 @@ const router = Router();
  *                       timestamp:
  *                         type: string
  *                         format: date-time
+ *                 suspiciousActivity:
+ *                   type: object
+ *                   description: Auth, prediction, and chat abuse heuristics for operators
+ *                   properties:
+ *                     lookbackHours:
+ *                       type: integer
+ *                     hitThreshold:
+ *                       type: integer
+ *                     byCategory:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           category:
+ *                             type: string
+ *                             enum: [auth, prediction, chat]
+ *                           hits:
+ *                             type: integer
+ *                           uniqueKeys:
+ *                             type: integer
+ *                     flaggedActors:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           key:
+ *                             type: string
+ *                           endpoint:
+ *                             type: string
+ *                           hits:
+ *                             type: integer
+ *                           category:
+ *                             type: string
+ *                           userId:
+ *                             type: string
+ *                           ip:
+ *                             type: string
+ *                           lastSeenAt:
+ *                             type: string
+ *                             format: date-time
  *       401:
  *         $ref: '#/components/responses/Unauthorized'
  *       403:
@@ -86,7 +128,7 @@ router.get('/rate-limits', requireAdmin, async (req: Request, res: Response) => 
 
 /**
  * @openapi
- * /admin/metrics/rate-limits/clear:
+ * /api/admin/metrics/rate-limits/clear:
  *   post:
  *     summary: Clear old rate-limit metrics
  *     description: Deletes rate-limit records older than a specific number of days. Admin only.

--- a/src/routes/chat.routes.ts
+++ b/src/routes/chat.routes.ts
@@ -8,11 +8,34 @@ import { sendMessageSchema } from '../schemas/chat.schema';
 const router = Router();
 
 /**
- * POST /api/chat/send
- * Send a new chat message (Authenticated users only, rate limited)
- *
- * Body: { content: string }
- * Response: { success: true, message: ChatMessage }
+ * @openapi
+ * /api/chat/send:
+ *   post:
+ *     tags: [Chat]
+ *     summary: Send a chat message
+ *     description: |
+ *       Authenticated users only. Rate limit: **5 messages per minute per user**. On limit, responds with **429**.
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [content]
+ *             properties:
+ *               content:
+ *                 type: string
+ *     responses:
+ *       201:
+ *         description: Message created
+ *       429:
+ *         description: Too many messages
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RateLimitResponse'
  */
 router.post('/send', authenticateUser, chatMessageRateLimiter, validate(sendMessageSchema), (async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
   try {

--- a/src/routes/leaderboard.routes.ts
+++ b/src/routes/leaderboard.routes.ts
@@ -6,6 +6,7 @@ import {
   AuthenticatedRequest,
   optionalAuthentication,
 } from "../middleware/auth.middleware";
+import { batchLeaderboardRateLimiter } from "../middleware/rateLimiter.middleware";
 import { validate } from "../middleware/validate.middleware";
 import { batchLeaderboardQuerySchema } from "../schemas/predictions.schema";
 import { AppError } from "../utils/errors";
@@ -186,6 +187,7 @@ router.get(
 router.post(
   "/batch",
   authenticateUser,
+  batchLeaderboardRateLimiter,
   validate(batchLeaderboardQuerySchema),
   (async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
     try {

--- a/src/routes/predictions.routes.ts
+++ b/src/routes/predictions.routes.ts
@@ -3,7 +3,10 @@ import {
    authenticateUser,
    AuthenticatedRequest,
 } from '../middleware/auth.middleware';
-import { predictionRateLimiter } from '../middleware/rateLimiter.middleware';
+import {
+   batchPredictionRateLimiter,
+   predictionRateLimiter,
+} from '../middleware/rateLimiter.middleware';
 import { validate } from '../middleware/validate.middleware';
 import {
    batchSubmitPredictionsSchema,
@@ -128,6 +131,8 @@ router.post(
  *   post:
  *     tags: [Predictions]
  *     summary: Submit multiple predictions at once
+ *     description: |
+ *       Batch submit up to 50 predictions. Rate limit: **3 batch requests per minute per user** (stricter than single submit). On limit, responds with **429**.
  *     security:
  *       - bearerAuth: []
  *     requestBody:
@@ -146,11 +151,17 @@ router.post(
  *     responses:
  *       200:
  *         description: Predictions processed
+ *       429:
+ *         description: Too many batch requests
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RateLimitResponse'
  */
 router.post(
    '/batch-submit',
    authenticateUser,
-   predictionRateLimiter,
+   batchPredictionRateLimiter,
    validate(batchSubmitPredictionsSchema),
    (async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
       try {

--- a/src/security/rate-limit-endpoints.ts
+++ b/src/security/rate-limit-endpoints.ts
@@ -1,0 +1,28 @@
+/**
+ * Rate-limit endpoint names and operator-facing categories.
+ * Keep in sync with rateLimiter.middleware.ts `name` fields.
+ */
+export type RateLimitCategory = "auth" | "prediction" | "chat" | "admin" | "oracle" | "other";
+
+export const RATE_LIMIT_ENDPOINT_CATEGORIES: Record<string, RateLimitCategory> = {
+  "auth/challenge": "auth",
+  "auth/connect": "auth",
+  "auth/general": "auth",
+  "chat/message": "chat",
+  "prediction/submit": "prediction",
+  "prediction/batch-submit": "prediction",
+  "admin/round-create": "admin",
+  "oracle/round-resolve": "oracle",
+  "leaderboard/batch": "other",
+};
+
+export function getRateLimitCategory(endpoint: string): RateLimitCategory {
+  return RATE_LIMIT_ENDPOINT_CATEGORIES[endpoint] ?? "other";
+}
+
+/** Endpoints surfaced in the operator suspicious-activity dashboard */
+export const OPERATOR_MONITORED_CATEGORIES: RateLimitCategory[] = [
+  "auth",
+  "prediction",
+  "chat",
+];

--- a/src/security/route-auth.registry.ts
+++ b/src/security/route-auth.registry.ts
@@ -1,0 +1,123 @@
+import { UserRole } from "@prisma/client";
+
+/**
+ * Minimum authorization required to call a route.
+ * Used by tests and documentation to prevent auth drift when routes are added.
+ */
+export enum RouteAuthLevel {
+  PUBLIC = "public",
+  /** Valid JWT; any role */
+  AUTHENTICATED = "authenticated",
+  /** Valid JWT with ADMIN role */
+  ADMIN = "admin",
+  /** Valid JWT with ORACLE or ADMIN role */
+  ORACLE = "oracle",
+  /** Valid JWT optional; enriches response when present */
+  OPTIONAL_AUTH = "optional_auth",
+}
+
+export interface RouteAuthEntry {
+  method: "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
+  /** Full mounted path (e.g. /api/predictions/submit) */
+  path: string;
+  auth: RouteAuthLevel;
+  /** Human-readable note for contributors */
+  notes?: string;
+}
+
+/**
+ * Canonical map of HTTP API routes and their authorization requirements.
+ * Update this registry whenever a route is added or its auth changes.
+ */
+export const ROUTE_AUTH_REGISTRY: RouteAuthEntry[] = [
+  // Auth
+  { method: "POST", path: "/api/auth/challenge", auth: RouteAuthLevel.PUBLIC, notes: "Rate limited per IP" },
+  { method: "POST", path: "/api/auth/connect", auth: RouteAuthLevel.PUBLIC, notes: "Rate limited per IP" },
+
+  // User
+  { method: "GET", path: "/api/user/profile", auth: RouteAuthLevel.AUTHENTICATED },
+  { method: "GET", path: "/api/user/balance", auth: RouteAuthLevel.AUTHENTICATED },
+  { method: "GET", path: "/api/user/stats", auth: RouteAuthLevel.AUTHENTICATED },
+  { method: "PATCH", path: "/api/user/profile", auth: RouteAuthLevel.AUTHENTICATED },
+  { method: "GET", path: "/api/user/transactions", auth: RouteAuthLevel.AUTHENTICATED },
+  { method: "GET", path: "/api/user/:walletAddress/public-profile", auth: RouteAuthLevel.PUBLIC },
+
+  // Rounds
+  { method: "POST", path: "/api/rounds/start", auth: RouteAuthLevel.ADMIN },
+  { method: "GET", path: "/api/rounds/:id", auth: RouteAuthLevel.PUBLIC },
+  { method: "GET", path: "/api/rounds/active", auth: RouteAuthLevel.PUBLIC },
+  { method: "POST", path: "/api/rounds/:id/resolve", auth: RouteAuthLevel.ORACLE },
+
+  // Predictions
+  { method: "POST", path: "/api/predictions/submit", auth: RouteAuthLevel.AUTHENTICATED },
+  { method: "POST", path: "/api/predictions/batch-submit", auth: RouteAuthLevel.AUTHENTICATED },
+  { method: "GET", path: "/api/predictions/user", auth: RouteAuthLevel.AUTHENTICATED },
+  { method: "GET", path: "/api/predictions/round/:roundId", auth: RouteAuthLevel.PUBLIC },
+
+  // Education
+  { method: "GET", path: "/api/education/guides", auth: RouteAuthLevel.PUBLIC },
+  { method: "GET", path: "/api/education/tip", auth: RouteAuthLevel.PUBLIC },
+
+  // Leaderboard
+  { method: "GET", path: "/api/leaderboard", auth: RouteAuthLevel.OPTIONAL_AUTH },
+  { method: "POST", path: "/api/leaderboard/batch", auth: RouteAuthLevel.AUTHENTICATED },
+
+  // Chat
+  { method: "POST", path: "/api/chat/send", auth: RouteAuthLevel.AUTHENTICATED },
+  { method: "GET", path: "/api/chat/history", auth: RouteAuthLevel.PUBLIC },
+
+  // Notifications (all authenticated)
+  { method: "GET", path: "/api/notifications", auth: RouteAuthLevel.AUTHENTICATED },
+  { method: "GET", path: "/api/notifications/unread-count", auth: RouteAuthLevel.AUTHENTICATED },
+  { method: "GET", path: "/api/notifications/:id", auth: RouteAuthLevel.AUTHENTICATED },
+  { method: "PATCH", path: "/api/notifications/:id/read", auth: RouteAuthLevel.AUTHENTICATED },
+  { method: "PATCH", path: "/api/notifications/read-all", auth: RouteAuthLevel.AUTHENTICATED },
+  { method: "DELETE", path: "/api/notifications/:id", auth: RouteAuthLevel.AUTHENTICATED },
+  { method: "DELETE", path: "/api/notifications", auth: RouteAuthLevel.AUTHENTICATED },
+
+  // Admin
+  { method: "GET", path: "/api/admin/metrics/rate-limits", auth: RouteAuthLevel.ADMIN },
+  { method: "POST", path: "/api/admin/metrics/rate-limits/clear", auth: RouteAuthLevel.ADMIN },
+  { method: "GET", path: "/api/admin/cors-diagnostics", auth: RouteAuthLevel.ADMIN },
+  { method: "GET", path: "/api/admin/dead-letter", auth: RouteAuthLevel.ADMIN },
+  { method: "POST", path: "/api/admin/dead-letter/retry-all", auth: RouteAuthLevel.ADMIN },
+  { method: "POST", path: "/api/admin/dead-letter/:id/retry", auth: RouteAuthLevel.ADMIN },
+
+  // System / misc API
+  { method: "GET", path: "/api/price", auth: RouteAuthLevel.PUBLIC },
+  { method: "GET", path: "/api/errors", auth: RouteAuthLevel.PUBLIC },
+  { method: "GET", path: "/metrics", auth: RouteAuthLevel.PUBLIC },
+  { method: "GET", path: "/health", auth: RouteAuthLevel.PUBLIC },
+  { method: "GET", path: "/", auth: RouteAuthLevel.PUBLIC },
+];
+
+/** Roles that satisfy ORACLE-level routes */
+export const ORACLE_ALLOWED_ROLES: UserRole[] = [UserRole.ORACLE, UserRole.ADMIN];
+
+export function registryKey(entry: RouteAuthEntry): string {
+  return `${entry.method} ${entry.path}`;
+}
+
+export function getRegistryByPath(): Map<string, RouteAuthEntry> {
+  const map = new Map<string, RouteAuthEntry>();
+  for (const entry of ROUTE_AUTH_REGISTRY) {
+    const key = registryKey(entry);
+    if (map.has(key)) {
+      throw new Error(`Duplicate route auth registry entry: ${key}`);
+    }
+    map.set(key, entry);
+  }
+  return map;
+}
+
+export function getProtectedRoutes(): RouteAuthEntry[] {
+  return ROUTE_AUTH_REGISTRY.filter((e) => e.auth !== RouteAuthLevel.PUBLIC);
+}
+
+export function getAdminRoutes(): RouteAuthEntry[] {
+  return ROUTE_AUTH_REGISTRY.filter((e) => e.auth === RouteAuthLevel.ADMIN);
+}
+
+export function getOracleRoutes(): RouteAuthEntry[] {
+  return ROUTE_AUTH_REGISTRY.filter((e) => e.auth === RouteAuthLevel.ORACLE);
+}

--- a/src/services/rate-limit-metrics.service.ts
+++ b/src/services/rate-limit-metrics.service.ts
@@ -1,5 +1,45 @@
 import { prisma } from '../lib/prisma';
 import logger from '../utils/logger';
+import {
+  getRateLimitCategory,
+  OPERATOR_MONITORED_CATEGORIES,
+  RateLimitCategory,
+} from '../security/rate-limit-endpoints';
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/** Minimum hits in the lookback window before an actor is flagged as suspicious */
+const SUSPICIOUS_HIT_THRESHOLD = parsePositiveInt(
+  process.env.RATE_LIMIT_SUSPICIOUS_HIT_THRESHOLD,
+  5,
+);
+
+/** Lookback window for suspicious-activity heuristics (hours) */
+const SUSPICIOUS_LOOKBACK_HOURS = parsePositiveInt(
+  process.env.RATE_LIMIT_SUSPICIOUS_LOOKBACK_HOURS,
+  24,
+);
+
+export interface CategoryActivitySummary {
+  category: RateLimitCategory;
+  hits: number;
+  uniqueKeys: number;
+  topEndpoints: Array<{ endpoint: string; hits: number }>;
+}
+
+export interface SuspiciousActor {
+  key: string;
+  endpoint: string;
+  hits: number;
+  category: RateLimitCategory;
+  userId: string | null;
+  ip: string | null;
+  lastSeenAt: Date;
+}
 
 export class RateLimitMetricsService {
   /**
@@ -64,6 +104,8 @@ export class RateLimitMetricsService {
         take: limit,
       });
 
+      const suspiciousActivity = await this.getSuspiciousActivity(limit);
+
       return {
         topEndpoints: topEndpoints.map(e => ({
           endpoint: e.endpoint,
@@ -75,6 +117,7 @@ export class RateLimitMetricsService {
           hits: a._count.id,
         })),
         recentEvents,
+        suspiciousActivity,
       };
     } catch (error) {
       logger.error('Failed to get rate-limit summary:', error);
@@ -83,12 +126,153 @@ export class RateLimitMetricsService {
   }
 
   /**
+   * Operator-facing view of auth, prediction, and chat rate-limit abuse patterns.
+   */
+  async getSuspiciousActivity(limit: number = 10): Promise<{
+    lookbackHours: number;
+    hitThreshold: number;
+    byCategory: CategoryActivitySummary[];
+    flaggedActors: SuspiciousActor[];
+  }> {
+    const since = new Date();
+    since.setHours(since.getHours() - SUSPICIOUS_LOOKBACK_HOURS);
+
+    const recentHits = await prisma.rateLimitMetric.findMany({
+      where: { timestamp: { gte: since } },
+      orderBy: { timestamp: 'desc' },
+    });
+
+    const monitored = recentHits.filter((hit) =>
+      OPERATOR_MONITORED_CATEGORIES.includes(getRateLimitCategory(hit.endpoint)),
+    );
+
+    const byCategory = this.buildCategorySummaries(monitored, limit);
+    const flaggedActors = this.buildFlaggedActors(monitored, limit);
+
+    return {
+      lookbackHours: SUSPICIOUS_LOOKBACK_HOURS,
+      hitThreshold: SUSPICIOUS_HIT_THRESHOLD,
+      byCategory,
+      flaggedActors,
+    };
+  }
+
+  private buildCategorySummaries(
+    hits: Array<{
+      endpoint: string;
+      key: string;
+    }>,
+    limit: number,
+  ): CategoryActivitySummary[] {
+    const categoryMap = new Map<
+      RateLimitCategory,
+      { hits: number; keys: Set<string>; endpointCounts: Map<string, number> }
+    >();
+
+    for (const category of OPERATOR_MONITORED_CATEGORIES) {
+      categoryMap.set(category, {
+        hits: 0,
+        keys: new Set(),
+        endpointCounts: new Map(),
+      });
+    }
+
+    for (const hit of hits) {
+      const category = getRateLimitCategory(hit.endpoint);
+      if (!OPERATOR_MONITORED_CATEGORIES.includes(category)) continue;
+
+      const bucket = categoryMap.get(category)!;
+      bucket.hits += 1;
+      bucket.keys.add(hit.key);
+      bucket.endpointCounts.set(
+        hit.endpoint,
+        (bucket.endpointCounts.get(hit.endpoint) ?? 0) + 1,
+      );
+    }
+
+    return OPERATOR_MONITORED_CATEGORIES.map((category) => {
+      const bucket = categoryMap.get(category)!;
+      const topEndpoints = [...bucket.endpointCounts.entries()]
+        .map(([endpoint, hitCount]) => ({ endpoint, hits: hitCount }))
+        .sort((a, b) => b.hits - a.hits)
+        .slice(0, limit);
+
+      return {
+        category,
+        hits: bucket.hits,
+        uniqueKeys: bucket.keys.size,
+        topEndpoints,
+      };
+    });
+  }
+
+  private buildFlaggedActors(
+    hits: Array<{
+      endpoint: string;
+      key: string;
+      userId: string | null;
+      ip: string | null;
+      timestamp: Date;
+    }>,
+    limit: number,
+  ): SuspiciousActor[] {
+    const grouped = new Map<
+      string,
+      {
+        endpoint: string;
+        key: string;
+        hits: number;
+        userId: string | null;
+        ip: string | null;
+        lastSeenAt: Date;
+      }
+    >();
+
+    for (const hit of hits) {
+      const groupKey = `${hit.endpoint}::${hit.key}`;
+      const existing = grouped.get(groupKey);
+      if (!existing) {
+        grouped.set(groupKey, {
+          endpoint: hit.endpoint,
+          key: hit.key,
+          hits: 1,
+          userId: hit.userId,
+          ip: hit.ip,
+          lastSeenAt: hit.timestamp,
+        });
+        continue;
+      }
+
+      existing.hits += 1;
+      if (hit.timestamp > existing.lastSeenAt) {
+        existing.lastSeenAt = hit.timestamp;
+        existing.userId = hit.userId ?? existing.userId;
+        existing.ip = hit.ip ?? existing.ip;
+      }
+    }
+
+    return [...grouped.values()]
+      .filter((entry) => entry.hits >= SUSPICIOUS_HIT_THRESHOLD)
+      .sort((a, b) => b.hits - a.hits)
+      .slice(0, limit)
+      .map((entry) => ({
+        key: entry.key,
+        endpoint: entry.endpoint,
+        hits: entry.hits,
+        category: getRateLimitCategory(entry.endpoint),
+        userId: entry.userId,
+        ip: entry.ip,
+        lastSeenAt: entry.lastSeenAt,
+      }));
+  }
+
+  /**
    * Clears old metrics (optional, for maintenance)
    */
   async clearOldMetrics(days: number = 7): Promise<number> {
     const date = new Date();
     date.setDate(date.getDate() - days);
-    
+
     try {
       const result = await prisma.rateLimitMetric.deleteMany({
         where: {

--- a/src/tests/openapi.spec.ts
+++ b/src/tests/openapi.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "@jest/globals";
+import { swaggerSpec } from "../docs/openapi";
+
+const REQUIRED_OPERATIONS: Array<{ path: string; method: string }> = [
+  { path: "/api/auth/challenge", method: "post" },
+  { path: "/api/auth/connect", method: "post" },
+  { path: "/api/predictions/submit", method: "post" },
+  { path: "/api/predictions/batch-submit", method: "post" },
+  { path: "/api/chat/send", method: "post" },
+  { path: "/api/admin/metrics/rate-limits", method: "get" },
+  { path: "/api/rounds/start", method: "post" },
+];
+
+describe("OpenAPI spec", () => {
+  it("documents core gameplay and admin routes", () => {
+    const paths = (swaggerSpec as { paths?: Record<string, Record<string, unknown>> }).paths ?? {};
+
+    for (const { path, method } of REQUIRED_OPERATIONS) {
+      expect(paths[path]?.[method]).toBeDefined();
+    }
+  });
+
+  it("documents 429 response on batch prediction submit", () => {
+    const paths = (swaggerSpec as { paths?: Record<string, any> }).paths ?? {};
+    const batchOp = paths["/api/predictions/batch-submit"]?.post;
+    expect(batchOp?.responses?.["429"]).toBeDefined();
+  });
+});

--- a/src/tests/rate-limit-metrics.service.spec.ts
+++ b/src/tests/rate-limit-metrics.service.spec.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import { RateLimitMetricsService } from "../services/rate-limit-metrics.service";
+
+const mockFindMany = jest.fn();
+const mockCreate = jest.fn();
+const mockGroupBy = jest.fn();
+const mockDeleteMany = jest.fn();
+
+jest.mock("../lib/prisma", () => ({
+  prisma: {
+    rateLimitMetric: {
+      findMany: (...args: unknown[]) => mockFindMany(...args),
+      create: (...args: unknown[]) => mockCreate(...args),
+      groupBy: (...args: unknown[]) => mockGroupBy(...args),
+      deleteMany: (...args: unknown[]) => mockDeleteMany(...args),
+    },
+  },
+}));
+
+describe("RateLimitMetricsService.getSuspiciousActivity", () => {
+  const service = new RateLimitMetricsService();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("groups monitored categories and flags repeat offenders", async () => {
+    const now = new Date();
+    mockFindMany.mockResolvedValue([
+      {
+        endpoint: "auth/connect",
+        key: "ip-1",
+        userId: null,
+        ip: "1.2.3.4",
+        timestamp: now,
+      },
+      {
+        endpoint: "auth/connect",
+        key: "ip-1",
+        userId: null,
+        ip: "1.2.3.4",
+        timestamp: now,
+      },
+      {
+        endpoint: "auth/connect",
+        key: "ip-1",
+        userId: null,
+        ip: "1.2.3.4",
+        timestamp: now,
+      },
+      {
+        endpoint: "auth/connect",
+        key: "ip-1",
+        userId: null,
+        ip: "1.2.3.4",
+        timestamp: now,
+      },
+      {
+        endpoint: "auth/connect",
+        key: "ip-1",
+        userId: null,
+        ip: "1.2.3.4",
+        timestamp: now,
+      },
+      {
+        endpoint: "chat/message",
+        key: "user-1",
+        userId: "user-1",
+        ip: "127.0.0.1",
+        timestamp: now,
+      },
+      {
+        endpoint: "prediction/batch-submit",
+        key: "user-2",
+        userId: "user-2",
+        ip: "127.0.0.1",
+        timestamp: now,
+      },
+    ]);
+
+    const result = await service.getSuspiciousActivity(5);
+
+    expect(result.byCategory).toHaveLength(3);
+    const authCategory = result.byCategory.find((c) => c.category === "auth");
+    expect(authCategory?.hits).toBe(5);
+    expect(authCategory?.uniqueKeys).toBe(1);
+
+    expect(result.flaggedActors).toHaveLength(1);
+    expect(result.flaggedActors[0]).toMatchObject({
+      endpoint: "auth/connect",
+      key: "ip-1",
+      hits: 5,
+      category: "auth",
+    });
+  });
+});

--- a/src/tests/rate-limit-visibility.spec.ts
+++ b/src/tests/rate-limit-visibility.spec.ts
@@ -74,6 +74,9 @@ describe('Rate Limit Visibility', () => {
     expect(response.body).toHaveProperty('topEndpoints');
     expect(response.body).toHaveProperty('topAbusers');
     expect(response.body).toHaveProperty('recentEvents');
+    expect(response.body).toHaveProperty('suspiciousActivity');
+    expect(response.body.suspiciousActivity).toHaveProperty('byCategory');
+    expect(response.body.suspiciousActivity).toHaveProperty('flaggedActors');
   });
 
   it('should deny access to rate limit metrics for regular users', async () => {

--- a/src/tests/rate-limiter.middleware.spec.ts
+++ b/src/tests/rate-limiter.middleware.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "@jest/globals";
+import { RATE_LIMIT_POLICIES } from "../middleware/rateLimiter.middleware";
+import { getRateLimitCategory } from "../security/rate-limit-endpoints";
+
+describe("rateLimiter.middleware", () => {
+  it("assigns batch prediction endpoint to prediction category", () => {
+    expect(getRateLimitCategory("prediction/batch-submit")).toBe("prediction");
+  });
+
+  it("uses stricter batch prediction limits than single submit", () => {
+    expect(RATE_LIMIT_POLICIES.predictionBatchSubmit.max).toBeLessThan(
+      RATE_LIMIT_POLICIES.predictionSubmit.max,
+    );
+    expect(RATE_LIMIT_POLICIES.predictionBatchSubmit.windowMs).toBe(
+      RATE_LIMIT_POLICIES.predictionSubmit.windowMs,
+    );
+  });
+
+  it("defines batch leaderboard rate limit policy", () => {
+    expect(RATE_LIMIT_POLICIES.leaderboardBatch.max).toBeGreaterThan(0);
+    expect(RATE_LIMIT_POLICIES.leaderboardBatch.windowMs).toBeGreaterThan(0);
+  });
+});

--- a/src/tests/route-auth.registry.spec.ts
+++ b/src/tests/route-auth.registry.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  getAdminRoutes,
+  getOracleRoutes,
+  getProtectedRoutes,
+  getRegistryByPath,
+  ROUTE_AUTH_REGISTRY,
+  RouteAuthLevel,
+} from "../security/route-auth.registry";
+
+describe("route-auth.registry", () => {
+  it("has no duplicate method+path entries", () => {
+    expect(() => getRegistryByPath()).not.toThrow();
+    expect(ROUTE_AUTH_REGISTRY.length).toBeGreaterThan(20);
+  });
+
+  it("marks admin-only routes as ADMIN", () => {
+    const adminPaths = getAdminRoutes().map((r) => r.path);
+    expect(adminPaths).toContain("/api/rounds/start");
+    expect(adminPaths).toContain("/api/admin/metrics/rate-limits");
+    expect(adminPaths.every((p) => p.startsWith("/api/"))).toBe(true);
+  });
+
+  it("marks oracle resolve route as ORACLE", () => {
+    const oraclePaths = getOracleRoutes().map((r) => r.path);
+    expect(oraclePaths).toEqual(["/api/rounds/:id/resolve"]);
+  });
+
+  it("requires auth on batch mutation endpoints", () => {
+    const protectedPaths = getProtectedRoutes();
+    const batchPrediction = protectedPaths.find(
+      (r) => r.path === "/api/predictions/batch-submit",
+    );
+    const batchLeaderboard = protectedPaths.find(
+      (r) => r.path === "/api/leaderboard/batch",
+    );
+
+    expect(batchPrediction?.auth).toBe(RouteAuthLevel.AUTHENTICATED);
+    expect(batchLeaderboard?.auth).toBe(RouteAuthLevel.AUTHENTICATED);
+  });
+});

--- a/src/tests/security.spec.ts
+++ b/src/tests/security.spec.ts
@@ -4,9 +4,17 @@
  * Uses mocked Prisma so no database is required.
  * All assertions are against the Express HTTP layer (createApp / supertest).
  */
-import { describe, it, expect, beforeAll, afterAll, afterEach } from "@jest/globals";
+import { describe, it, expect, beforeAll, afterAll, afterEach, beforeEach } from "@jest/globals";
 import request from "supertest";
 import { Express } from "express";
+import { UserRole } from "@prisma/client";
+import {
+  getAdminRoutes,
+  getOracleRoutes,
+  registryKey,
+  RouteAuthLevel,
+  ROUTE_AUTH_REGISTRY,
+} from "../security/route-auth.registry";
 
 jest.mock("../lib/prisma", () => ({
   prisma: {
@@ -25,14 +33,18 @@ jest.mock("../lib/prisma", () => ({
   },
 }));
 
+const passthroughLimiter = (_req: any, _res: any, next: any) => next();
+
 jest.mock("../middleware/rateLimiter.middleware", () => ({
-  challengeRateLimiter: (_req: any, _res: any, next: any) => next(),
-  connectRateLimiter: (_req: any, _res: any, next: any) => next(),
-  authRateLimiter: (_req: any, _res: any, next: any) => next(),
-  chatMessageRateLimiter: (_req: any, _res: any, next: any) => next(),
-  predictionRateLimiter: (_req: any, _res: any, next: any) => next(),
-  adminRoundRateLimiter: (_req: any, _res: any, next: any) => next(),
-  oracleResolveRateLimiter: (_req: any, _res: any, next: any) => next(),
+  challengeRateLimiter: passthroughLimiter,
+  connectRateLimiter: passthroughLimiter,
+  authRateLimiter: passthroughLimiter,
+  chatMessageRateLimiter: passthroughLimiter,
+  predictionRateLimiter: passthroughLimiter,
+  batchPredictionRateLimiter: passthroughLimiter,
+  batchLeaderboardRateLimiter: passthroughLimiter,
+  adminRoundRateLimiter: passthroughLimiter,
+  oracleResolveRateLimiter: passthroughLimiter,
 }));
 
 const originalEnv = process.env;
@@ -332,5 +344,90 @@ describe("getHttpCorsOrigins()", () => {
     expect(result).not.toContain("");
     expect(result).toContain("https://app.example.com");
     expect(result).toContain("https://staging.example.com");
+  });
+});
+
+// ── Route authorization registry (drift prevention) ─────────────────────────
+
+describe("Route authorization registry", () => {
+  it("has unique registry keys for every documented route", () => {
+    const keys = ROUTE_AUTH_REGISTRY.map(registryKey);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("blocks non-admin users from admin registry routes", async () => {
+    setEnv({ NODE_ENV: "development", JWT_SECRET: "test-secret" });
+    jest.resetModules();
+
+    const { prisma: freshPrisma } = require("../lib/prisma") as {
+      prisma: { user: { findUnique: jest.Mock } };
+    };
+    const { generateToken: freshGenerateToken } = require("../utils/jwt.util");
+
+    const regularUser = {
+      id: "user-regular",
+      walletAddress: "GUSER_REGULAR_TEST_AAAAAAAAAAAAAAA",
+      role: UserRole.USER,
+    };
+    freshPrisma.user.findUnique.mockResolvedValue(regularUser);
+    const token = freshGenerateToken(
+      regularUser.id,
+      regularUser.walletAddress,
+      regularUser.role,
+    );
+
+    const { createApp } = require("../index");
+    const app = createApp();
+
+    for (const route of getAdminRoutes()) {
+      const path = route.path.replace(":id", "test-id");
+      const method = route.method.toLowerCase() as "get" | "post";
+      const req = request(app)[method](path).set("Authorization", `Bearer ${token}`);
+      const res = await req;
+
+      expect(res.status).toBe(403);
+    }
+  });
+
+  it("blocks regular users from starting rounds (oracle/admin only actions)", async () => {
+    setEnv({ NODE_ENV: "development", JWT_SECRET: "test-secret" });
+    jest.resetModules();
+
+    const { prisma: freshPrisma } = require("../lib/prisma") as {
+      prisma: { user: { findUnique: jest.Mock } };
+    };
+    const { generateToken: freshGenerateToken } = require("../utils/jwt.util");
+
+    const regularUser = {
+      id: "user-regular-2",
+      walletAddress: "GUSER_REGULAR2_TEST_AAAAAAAAAAAAAA",
+      role: UserRole.USER,
+    };
+    freshPrisma.user.findUnique.mockResolvedValue(regularUser);
+    const token = freshGenerateToken(
+      regularUser.id,
+      regularUser.walletAddress,
+      regularUser.role,
+    );
+
+    const { createApp } = require("../index");
+    const app = createApp();
+
+    const res = await request(app)
+      .post("/api/rounds/start")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ mode: 0, startPrice: 0.5, duration: 60 });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("documents oracle routes separately from admin routes", () => {
+    const oracleOnly = getOracleRoutes().filter(
+      (r) => r.auth === RouteAuthLevel.ORACLE,
+    );
+    expect(oracleOnly.length).toBeGreaterThan(0);
+    expect(getAdminRoutes().some((r) => r.path === "/api/rounds/:id/resolve")).toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
## Summary

This PR addresses four Stellar Wave 5 backend reliability issues in one cohesive pass:

- **#179 (security)** — Adds stricter per-user rate limits for high-impact batch mutations (`batch-submit` predictions, `leaderboard/batch`) separate from single-request limits, with Prometheus `rate_limit_hits_total` tracking.
- **#180 (observability)** — Extends admin rate-limit metrics with `suspiciousActivity` (auth / prediction / chat categories, flagged actors above a configurable threshold).
- **#182 (architecture)** — Introduces `src/security/route-auth.registry.ts` and refactors auth middleware around a shared `requireRole` helper; adds drift-prevention tests in `security.spec.ts`.
- **#183 (deployment)** — Adds `npm run docs:verify` and a CI build step that regenerates OpenAPI and asserts required routes exist; fixes admin/chat OpenAPI path prefixes; adds `openapi.spec.ts`.

Closes #179  
Closes #180  
Closes #182  
Closes #183

## Before / after

| Area | Before | After |
|------|--------|-------|
| Batch prediction abuse | Same 10/min limit as single submit | **3 batch requests/min** per user (up to 50 predictions each) |
| Batch leaderboard | No dedicated limit | **10 requests/min** per user |
| Operator visibility | Raw top endpoints/abusers only | Category breakdown (auth, prediction, chat) + flagged actors |
| Auth drift | Ad-hoc `requireAdmin` / `requireOracle` copies | Central `requireRole` + documented route registry |
| API docs | Admin paths missing `/api` prefix; chat undocumented | Correct prefixes; chat `send` documented; CI verifies generation |

## Risk notes

- **Batch prediction UX**: Legitimate power users hitting 3 batch calls/min will receive `429`. Tunable via `BATCH_PREDICTION_RATE_LIMIT_MAX` / `BATCH_PREDICTION_RATE_LIMIT_WINDOW_MS`.
- **Admin metrics payload**: `GET /api/admin/metrics/rate-limits` response shape grows with `suspiciousActivity` (backward compatible — new field only).
- **Auth middleware refactor**: Behavior preserved (401 without token, 403 for wrong role); covered by updated `security.spec.ts`.

## Test plan

- [ ] `npm run prisma:generate && npm run lint && npm run build`
- [ ] `npm run test:unit` — new specs: `rate-limiter.middleware`, `route-auth.registry`, `openapi`, `rate-limit-metrics.service`
- [ ] `npm run test:integration` — `security.spec.ts`, `rate-limit-visibility.spec.ts`
- [ ] `npm run docs:verify` — confirms required OpenAPI paths after build
- [ ] Manual: burst `POST /api/predictions/batch-submit` (>3/min) → `429`
- [ ] Manual: admin `GET /api/admin/metrics/rate-limits` → `suspiciousActivity` present