### PR TITLE
feat: add GET /api/user/:address/stats endpoint with mock data

### DIFF
--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -1,0 +1,24 @@
+export interface WalletStats {
+  address: string;
+  balance: number;
+  pendingWinnings: number;
+  totalWins: number;
+  totalLosses: number;
+  currentStreak: number;
+  xp: number;
+  rankTitle: string;
+}
+
+export function getMockWalletStats(address: string): WalletStats {
+  // TODO: Wire to contract get_user_stats() and get_pending_winnings()
+  return {
+    address,
+    balance: 1000,
+    pendingWinnings: 0,
+    totalWins: 3,
+    totalLosses: 1,
+    currentStreak: 3,
+    xp: 410,
+    rankTitle: "Rookie",
+  };
+}

--- a/src/routes/user.routes.ts
+++ b/src/routes/user.routes.ts
@@ -3,7 +3,8 @@ import { prisma } from "../lib/prisma";
 import { authenticateUser, AuthenticatedRequest } from "../middleware/auth.middleware";
 import { validate } from "../middleware/validate.middleware";
 import { updateProfileSchema } from "../schemas/user.schema";
-import { NotFoundError } from "../utils/errors";
+import { NotFoundError, ValidationError } from "../utils/errors";
+import { getMockWalletStats } from "../data/mockData";
 
 const router = Router();
 
@@ -193,6 +194,29 @@ router.get(
       next(error);
     }
   }) as any,
+);
+
+/**
+ * GET /api/user/:address/stats
+ * Returns mock wallet stats for a Stellar address (hackathon MVP)
+ */
+router.get(
+  "/:address/stats",
+  (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { address } = req.params;
+
+      // Stellar public keys: 56 characters starting with 'G'
+      if (!address || !/^G[A-Z2-7]{55}$/.test(address)) {
+        return next(new ValidationError("Invalid Stellar address"));
+      }
+
+      const stats = getMockWalletStats(address);
+      return res.json({ success: true, stats });
+    } catch (error) {
+      next(error);
+    }
+  },
 );
 
 /**


### PR DESCRIPTION
Returns per-wallet stats (balance, wins, losses, streak, xp, rank) for any Stellar address. Validates the address format and returns 400 for invalid input. Mock defaults in place until contract reads are wired up.


closes #219 