### PR TITLE
Implement API health and stats endpoints

### DIFF
--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -1,0 +1,6 @@
+export const platformStats = {
+   totalRounds: 1247,
+   totalVxlmDistributed: 4200000,
+   activePlayers: 893,
+   totalBetsPlaced: 8432,
+} as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,8 @@ import errorsRoutes from './routes/errors.routes';
 import corsDiagnosticsRoutes from './routes/admin-cors-diagnostics.routes';
 import deadLetterRoutes from './routes/admin-dead-letter.routes';
 import chatRoutes from './routes/chat.routes';
+import healthRoutes from './routes/health';
+import statsRoutes from './routes/stats';
 import swaggerUi from 'swagger-ui-express';
 import { swaggerSpec } from './docs/openapi';
 import { initializeSocket } from './socket';
@@ -162,6 +164,8 @@ export function createApp(): Express {
    app.use('/api/errors', errorsRoutes);
    app.use('/api/admin/cors-diagnostics', corsDiagnosticsRoutes);
    app.use('/api/admin/dead-letter', deadLetterRoutes);
+   app.use('/api/health', healthRoutes);
+   app.use('/api/stats', statsRoutes);
 
    // Prometheus metrics endpoint
    app.use('/metrics', metricsRoutes);

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -1,0 +1,12 @@
+import { Request, Response, Router } from 'express';
+
+const router = Router();
+
+router.get('/', (_req: Request, res: Response) => {
+   res.json({
+      status: 'ok',
+      timestamp: Date.now(),
+   });
+});
+
+export default router;

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -1,0 +1,11 @@
+import { Request, Response, Router } from 'express';
+import { platformStats } from '../data/mockData';
+
+const router = Router();
+
+router.get('/', (_req: Request, res: Response) => {
+   // TODO: Replace with live Stellar RPC queries via @stellar/stellar-sdk
+   res.json(platformStats);
+});
+
+export default router;

--- a/src/tests/health-stats.routes.spec.ts
+++ b/src/tests/health-stats.routes.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, beforeAll } from '@jest/globals';
+import express, { Express } from 'express';
+import request from 'supertest';
+import healthRoutes from '../routes/health';
+import statsRoutes from '../routes/stats';
+
+describe('health and platform stats routes', () => {
+   let app: Express;
+
+   beforeAll(() => {
+      app = express();
+      app.use('/api/health', healthRoutes);
+      app.use('/api/stats', statsRoutes);
+   });
+
+   it('returns the lightweight API health probe shape', async () => {
+      const before = Date.now();
+      const res = await request(app).get('/api/health');
+      const after = Date.now();
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+         status: 'ok',
+         timestamp: expect.any(Number),
+      });
+      expect(res.body.timestamp).toBeGreaterThanOrEqual(before);
+      expect(res.body.timestamp).toBeLessThanOrEqual(after);
+   });
+
+   it('returns landing-page platform stats from mock data', async () => {
+      const res = await request(app).get('/api/stats');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+         totalRounds: 1247,
+         totalVxlmDistributed: 4200000,
+         activePlayers: 893,
+         totalBetsPlaced: 8432,
+      });
+   });
+});


### PR DESCRIPTION
## Summary
- Add GET /api/health with the lightweight `{ status: "ok", timestamp }` payload for landing-page uptime probes.
- Add GET /api/stats backed by `src/data/mockData.ts` with the requested hackathon MVP counters.
- Mount both routes in the real Express app and add focused supertest coverage for the endpoint shapes.

Closes #215

## Validation
- `npm test -- --runTestsByPath src/tests/health-stats.routes.spec.ts` passed (2 tests).
- `git diff --check -- src/index.ts src/data/mockData.ts src/routes/health.ts src/routes/stats.ts src/tests/health-stats.routes.spec.ts` passed.
- Static route check confirmed `/api/health` and `/api/stats` are mounted from `src/index.ts`.
- Sensitive scan of changed files returned no account/payment/private-key markers.

## Existing upstream issue observed
- `npm run build` is currently blocked before compiling source by `tsconfig.json(19,27): error TS5103: Invalid value for '--ignoreDeprecations'.`