### PR TITLE
[Hackathon] Implement GET /api/health and GET /api/stats

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,8 @@ import cors from 'cors';
 import helmet from 'helmet';
 import morgan from 'morgan';
 import routes from './routes';
+import healthRoutes from './routes/health';
+import statsRoutes from './routes/stats';
 
 const app: Application = express();
 
@@ -11,6 +13,8 @@ app.use(cors({ origin: true }));
 app.use(helmet());
 app.use(morgan('combined'));
 
+app.use('/api', healthRoutes);
+app.use('/api', statsRoutes);
 app.use('/api', routes);
 
 export default app;

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -4,4 +4,11 @@ export const mockData = {
     { id: 'bitcoin', symbol: 'btc', price: 60000 },
     { id: 'ethereum', symbol: 'eth', price: 3000 },
   ],
+  // TODO: Replace with live Stellar RPC queries via @stellar/stellar-sdk
+  platformStats: {
+    totalRounds: 1247,
+    totalVxlmDistributed: 4200000,
+    activePlayers: 893,
+    totalBetsPlaced: 8432,
+  },
 };

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.get('/health', (_req, res) => {
+  res.json({
+    status: 'ok',
+    timestamp: Date.now(),
+  });
+});
+
+export default router;

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { mockData } from '../data/mockData';
+
+const router = Router();
+
+router.get('/stats', (_req, res) => {
+  res.json(mockData.platformStats);
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- Add `GET /api/health` returning `{ status, timestamp }` for uptime probes
- Add `GET /api/stats` returning mock platform counters from `mockData.ts`
- Wire both routes in `src/app.ts` so the landing page can integrate without blockchain setup

Closes #215

## Test plan
- [x] `curl http://localhost:3001/api/health` returns `{ status: ok, timestamp: <number> }`
- [x] `curl http://localhost:3001/api/stats` returns the expected mock stats shape
- [x] TODO comment present in `mockData.ts` for future Stellar RPC replacement