### PR TITLE
Add express-rate-limit per IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1846,6 +1846,30 @@ npx prisma migrate status
 
 ---
 
+## Hackathon API Rate Limits
+
+The lightweight hackathon server (`src/app.ts`, default port **3001**) applies per-IP throttling with [`express-rate-limit`](https://github.com/express-rate-limit/express-rate-limit) via `src/middleware/rateLimiter.ts`.
+
+| Limiter | Scope | Window | Max requests |
+| --- | --- | --- | --- |
+| `apiRateLimiter` | All `/api/*` routes | 1 minute | 100 |
+| `writeRateLimiter` | `POST`, `PUT`, `PATCH`, `DELETE` | 1 minute | 20 |
+| `betRateLimiter` | `POST /api/rounds/:id/bet` | 1 minute | 5 |
+
+When a client exceeds a limit, the API returns **429** with retry guidance:
+
+```json
+{
+  "error": "Too Many Requests",
+  "message": "Too many bet submissions from this IP. Please wait before placing another bet.",
+  "retryAfter": 60
+}
+```
+
+The `RateLimit-*` and `Retry-After` response headers are also set (`standardHeaders: true`).
+
+---
+
 ## Related Repositories
 
 - **Smart Contract**: [TevaLabs/Xelma-Blockchain](https://github.com/TevaLabs/Xelma-Blockchain)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
+        "express-rate-limit": "^8.5.2",
         "helmet": "^7.1.0",
         "morgan": "^1.10.0"
       },
@@ -714,6 +715,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -960,6 +979,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "express-rate-limit": "^8.5.2",
     "helmet": "^7.1.0",
     "morgan": "^1.10.0"
   },

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,8 @@ import cors from 'cors';
 import helmet from 'helmet';
 import morgan from 'morgan';
 import routes from './routes';
+import roundsRoutes from './routes/rounds';
+import { apiRateLimiter, writeRateLimiter } from './middleware/rateLimiter';
 
 const app: Application = express();
 
@@ -11,6 +13,9 @@ app.use(cors({ origin: true }));
 app.use(helmet());
 app.use(morgan('combined'));
 
+app.use('/api', apiRateLimiter);
+app.use('/api', writeRateLimiter);
+app.use('/api/rounds', roundsRoutes);
 app.use('/api', routes);
 
 export default app;

--- a/src/middleware/rateLimiter.ts
+++ b/src/middleware/rateLimiter.ts
@@ -1,0 +1,59 @@
+import rateLimit from 'express-rate-limit';
+import { Request, Response } from 'express';
+
+type RateLimitPolicy = {
+  windowMs: number;
+  max: number;
+  message: string;
+};
+
+/** Documented limits for operators and README */
+export const RATE_LIMIT_POLICIES = {
+  api: {
+    windowMs: 60 * 1000,
+    max: 100,
+    message:
+      'Too many requests from this IP. Please slow down and try again shortly.',
+  },
+  write: {
+    windowMs: 60 * 1000,
+    max: 20,
+    message:
+      'Too many write requests from this IP. Please wait before submitting again.',
+  },
+  bet: {
+    windowMs: 60 * 1000,
+    max: 5,
+    message:
+      'Too many bet submissions from this IP. Please wait before placing another bet.',
+  },
+} as const satisfies Record<string, RateLimitPolicy>;
+
+function createRateLimiter(policy: RateLimitPolicy, skip?: (req: Request) => boolean) {
+  return rateLimit({
+    windowMs: policy.windowMs,
+    max: policy.max,
+    standardHeaders: true,
+    legacyHeaders: false,
+    skip,
+    handler: (_req: Request, res: Response) => {
+      res.status(429).json({
+        error: 'Too Many Requests',
+        message: policy.message,
+        retryAfter: Math.ceil(policy.windowMs / 1000),
+      });
+    },
+  });
+}
+
+/** Baseline per-IP limit for all public `/api` traffic */
+export const apiRateLimiter = createRateLimiter(RATE_LIMIT_POLICIES.api);
+
+/** Stricter per-IP limit for mutation methods */
+export const writeRateLimiter = createRateLimiter(
+  RATE_LIMIT_POLICIES.write,
+  (req) => ['GET', 'HEAD', 'OPTIONS'].includes(req.method),
+);
+
+/** Strictest per-IP limit for bet submissions */
+export const betRateLimiter = createRateLimiter(RATE_LIMIT_POLICIES.bet);

--- a/src/routes/rounds.ts
+++ b/src/routes/rounds.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { betRateLimiter } from '../middleware/rateLimiter';
+
+const router = Router();
+
+// TODO: Call contract via Xelma TypeScript bindings — bets must go on-chain; this endpoint is logging/analytics only for now
+router.post('/:id/bet', betRateLimiter, (_req, res) => {
+  res.json({ success: true, message: 'Bet recorded (stub)' });
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- Add `src/middleware/rateLimiter.ts` with per-IP limits for all `/api` traffic, write methods, and bet submissions
- Wire limiters in `src/app.ts` and add a minimal `POST /api/rounds/:id/bet` stub for strict bet throttling
- Document rate limit policies in README

Closes #230

## Test plan
- [x] `POST /api/rounds/:id/bet` returns 200 for requests 1–5 within a minute
- [x] 6th bet request within the same window returns 429 with `retryAfter` guidance
- [x] `GET /api/prices` continues to work under normal usage