### PR TITLE
feat: bet stub API and on-chain active round reads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,17 @@
 PORT=3001
+
+# Database
+DATABASE_URL=postgresql://user:password@localhost:5432/xelma
+
+# Auth
+JWT_SECRET=change-me
+
+# Soroban / Stellar (SOROBAN_CONTRACT_ID + SOROBAN_RPC_URL for read-only chain reads)
+SOROBAN_CONTRACT_ID=
+SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+SOROBAN_NETWORK=testnet
+SOROBAN_ADMIN_SECRET=
+SOROBAN_ORACLE_SECRET=
+
+# Force database-only active round reads for local development
+ROUNDS_MOCK_MODE=false

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -13,6 +13,7 @@ export interface AppConfig {
   clientUrl: string;
   logLevel: string;
   apiOnly: boolean;
+  roundsMockMode: boolean;
 }
 
 export interface JwtConfig {
@@ -94,6 +95,7 @@ function buildConfig(): Config {
       "info",
     ),
     apiOnly: v.boolean(env.API_ONLY, false),
+    roundsMockMode: v.boolean(env.ROUNDS_MOCK_MODE, false),
   };
 
   const jwt: JwtConfig = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { createServer, Server as HttpServer } from 'http';
 import authRoutes from './routes/auth.routes';
 import userRoutes from './routes/user.routes';
 import roundsRoutes from './routes/rounds.routes';
+import betsRoutes from './routes/bets.routes';
 import predictionsRoutes from './routes/predictions.routes';
 import educationRoutes from './routes/education.routes';
 import leaderboardRoutes from './routes/leaderboard.routes';
@@ -153,6 +154,7 @@ export function createApp(): Express {
    app.use('/api/auth', authRoutes);
    app.use('/api/user', userRoutes);
    app.use('/api/rounds', roundsRoutes);
+   app.use('/api/bets', betsRoutes);
    app.use('/api/predictions', predictionsRoutes);
    app.use('/api/education', educationRoutes);
    app.use('/api/leaderboard', leaderboardRoutes);

--- a/src/routes/bets.routes.ts
+++ b/src/routes/bets.routes.ts
@@ -1,0 +1,84 @@
+import { Router, Response, NextFunction } from "express";
+import { validate } from "../middleware/validate.middleware";
+import { upDownBetSchema, precisionBetSchema } from "../schemas/bets.schema";
+import betService from "../services/bet.service";
+
+const router = Router();
+
+/**
+ * @swagger
+ * /api/bets/up-down:
+ *   post:
+ *     summary: Submit an UP/DOWN bet (stub)
+ *     tags: [bets]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [address, amount, side]
+ *             properties:
+ *               address: { type: string }
+ *               amount: { type: number }
+ *               side: { type: string, enum: [UP, DOWN] }
+ *     responses:
+ *       200:
+ *         description: Bet recorded (stub)
+ *       400:
+ *         description: Validation error
+ */
+router.post(
+  "/up-down",
+  validate(upDownBetSchema),
+  (req, res: Response, next: NextFunction) => {
+    try {
+      // TODO: Call contract via Xelma TypeScript bindings — bets must go on-chain;
+      // this endpoint is logging/analytics only for now
+      betService.recordUpDownBet(req.body);
+      res.json({ success: true, message: "Bet recorded (stub)" });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+/**
+ * @swagger
+ * /api/bets/precision:
+ *   post:
+ *     summary: Submit a Precision bet (stub)
+ *     tags: [bets]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [address, amount, predictedPrice]
+ *             properties:
+ *               address: { type: string }
+ *               amount: { type: number }
+ *               predictedPrice: { type: number }
+ *     responses:
+ *       200:
+ *         description: Bet recorded (stub)
+ *       400:
+ *         description: Validation error
+ */
+router.post(
+  "/precision",
+  validate(precisionBetSchema),
+  (req, res: Response, next: NextFunction) => {
+    try {
+      // TODO: Call contract via Xelma TypeScript bindings — bets must go on-chain;
+      // this endpoint is logging/analytics only for now
+      betService.recordPrecisionBet(req.body);
+      res.json({ success: true, message: "Bet recorded (stub)" });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+export default router;

--- a/src/routes/rounds.routes.ts
+++ b/src/routes/rounds.routes.ts
@@ -140,6 +140,46 @@ router.post('/start', requireAdmin, adminRoundRateLimiter, validate(startRoundSc
 
 /**
  * @swagger
+ * /api/rounds/active:
+ *   get:
+ *     summary: Get active rounds
+ *     description: Returns the on-chain active round when Soroban is configured; falls back to database rounds when RPC is unavailable or ROUNDS_MOCK_MODE=true.
+ *     tags: [rounds]
+ *     responses:
+ *       200:
+ *         description: Active rounds
+ *         content:
+ *           application/json:
+ *             example:
+ *               success: true
+ *               source: soroban
+ *               rounds: []
+ *       500:
+ *         description: Internal server error
+ *         content:
+ *           application/json:
+ *             $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         source: |
+ *           curl -X GET "$API_BASE_URL/api/rounds/active"
+ */
+router.get('/active', async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const { source, rounds } = await roundService.getActiveRoundsWithFallback();
+
+        res.json({
+            success: true,
+            source,
+            rounds,
+        });
+    } catch (error) {
+        next(error);
+    }
+});
+
+/**
+ * @swagger
  * /api/rounds/{id}:
  *   get:
  *     summary: Get a round by ID
@@ -186,43 +226,6 @@ router.get('/:id', async (req: Request, res: Response, next: NextFunction) => {
         res.json({
             success: true,
             round,
-        });
-    } catch (error) {
-        next(error);
-    }
-});
-
-/**
- * @swagger
- * /api/rounds/active:
- *   get:
- *     summary: Get active rounds
- *     tags: [rounds]
- *     responses:
- *       200:
- *         description: Active rounds
- *         content:
- *           application/json:
- *             example:
- *               success: true
- *               rounds: []
- *       500:
- *         description: Internal server error
- *         content:
- *           application/json:
- *             $ref: '#/components/schemas/ErrorResponse'
- *     x-codeSamples:
- *       - lang: cURL
- *         source: |
- *           curl -X GET "$API_BASE_URL/api/rounds/active"
- */
-router.get('/active', async (req: Request, res: Response, next: NextFunction) => {
-    try {
-        const rounds = await roundService.getActiveRounds();
-
-        res.json({
-            success: true,
-            rounds,
         });
     } catch (error) {
         next(error);

--- a/src/schemas/bets.schema.ts
+++ b/src/schemas/bets.schema.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+import { isValidStellarAddress } from "../services/stellar.service";
+
+const stellarAddressSchema = z
+  .string({ error: "address is required" })
+  .min(1, "address is required")
+  .refine(isValidStellarAddress, "Invalid Stellar wallet address format");
+
+export const upDownBetSchema = z.object({
+  address: stellarAddressSchema,
+  amount: z.number({ error: "amount is required" }).positive("amount must be a positive number"),
+  side: z.enum(["UP", "DOWN"], {
+    error: "side is required",
+    message: "side must be UP or DOWN",
+  }),
+});
+
+export const precisionBetSchema = z.object({
+  address: stellarAddressSchema,
+  amount: z.number({ error: "amount is required" }).positive("amount must be a positive number"),
+  predictedPrice: z
+    .number({ error: "predictedPrice is required" })
+    .positive("predictedPrice must be a positive number"),
+});

--- a/src/services/bet.service.ts
+++ b/src/services/bet.service.ts
@@ -1,0 +1,34 @@
+import logger from "../utils/logger";
+
+export interface UpDownBetInput {
+  address: string;
+  amount: number;
+  side: "UP" | "DOWN";
+}
+
+export interface PrecisionBetInput {
+  address: string;
+  amount: number;
+  predictedPrice: number;
+}
+
+/**
+ * Hackathon stub — records bet intent for frontend integration.
+ * TODO: Call contract via Xelma TypeScript bindings — bets must go on-chain;
+ * this endpoint is logging/analytics only for now.
+ */
+export class BetService {
+  recordUpDownBet(input: UpDownBetInput): void {
+    // TODO: Call contract via Xelma TypeScript bindings — bets must go on-chain;
+    // this endpoint is logging/analytics only for now
+    logger.info("UP/DOWN bet stub recorded", input);
+  }
+
+  recordPrecisionBet(input: PrecisionBetInput): void {
+    // TODO: Call contract via Xelma TypeScript bindings — bets must go on-chain;
+    // this endpoint is logging/analytics only for now
+    logger.info("Precision bet stub recorded", input);
+  }
+}
+
+export default new BetService();

--- a/src/services/round.service.ts
+++ b/src/services/round.service.ts
@@ -9,6 +9,12 @@ import { RoundLifecycleOutcome } from "../types/round.types";
 import { Decimal } from "@prisma/client/runtime/library";
 import { toDecimal, toNumber } from "../utils/decimal.util";
 import { roundsStartedTotal } from "../metrics/application.metrics";
+import config from "../config";
+import {
+  ActiveRoundSource,
+  mapDatabaseActiveRound,
+  mapSorobanActiveRound,
+} from "../utils/soroban-round.mapper";
 
 interface LegendsPriceRange {
   min: number;
@@ -160,6 +166,42 @@ export class RoundService {
       logger.error("Failed to get round:", error);
       throw error;
     }
+  }
+
+  /**
+   * Gets active rounds from Soroban when available, otherwise from the database.
+   * Set ROUNDS_MOCK_MODE=true to force database-only reads for local development.
+   */
+  async getActiveRoundsWithFallback(): Promise<{
+    source: ActiveRoundSource;
+    rounds: any[];
+  }> {
+    if (!config.app.roundsMockMode) {
+      try {
+        const onChainRound = await sorobanService.getActiveRound();
+        if (onChainRound) {
+          return {
+            source: "soroban",
+            rounds: [mapSorobanActiveRound(onChainRound)],
+          };
+        }
+      } catch (error) {
+        logger.warn(
+          "Failed to fetch active round from Soroban; falling back to database",
+          error,
+        );
+      }
+    }
+
+    const dbRounds = await this.getActiveRounds();
+    if (dbRounds.length > 0) {
+      return {
+        source: "database",
+        rounds: dbRounds.map((round) => mapDatabaseActiveRound(round)),
+      };
+    }
+
+    return { source: "none", rounds: [] };
   }
 
   /**

--- a/src/services/soroban.service.ts
+++ b/src/services/soroban.service.ts
@@ -58,9 +58,9 @@ export class SorobanService {
       const adminSecret = process.env.SOROBAN_ADMIN_SECRET;
       const oracleSecret = process.env.SOROBAN_ORACLE_SECRET;
 
-      if (!contractId || !adminSecret || !oracleSecret) {
+      if (!contractId) {
         logger.warn(
-          "Soroban configuration or bindings missing. Soroban integration DISABLED.",
+          "SOROBAN_CONTRACT_ID not set. Soroban integration DISABLED.",
         );
         this.initialized = false;
         return;
@@ -74,11 +74,17 @@ export class SorobanService {
         rpcUrl,
       });
 
-      this.adminKeypair = Keypair.fromSecret(adminSecret);
-      this.oracleKeypair = Keypair.fromSecret(oracleSecret);
-      this.initialized = true;
+      if (adminSecret && oracleSecret) {
+        this.adminKeypair = Keypair.fromSecret(adminSecret);
+        this.oracleKeypair = Keypair.fromSecret(oracleSecret);
+        logger.info("Soroban service initialized (read-write)");
+      } else {
+        logger.info(
+          "Soroban service initialized (read-only; write keys not configured)",
+        );
+      }
 
-      logger.info("Soroban service initialized successfully");
+      this.initialized = true;
     } catch (error) {
       logger.error("Failed to initialize Soroban service:", error);
       this.initialized = false;

--- a/src/tests/bets.routes.spec.ts
+++ b/src/tests/bets.routes.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeAll } from "@jest/globals";
+import request from "supertest";
+import { Express } from "express";
+import { createApp } from "../index";
+
+const VALID_ADDRESS = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+describe("Bets Routes - stub endpoints", () => {
+  let app: Express;
+
+  beforeAll(() => {
+    app = createApp();
+  });
+
+  describe("POST /api/bets/up-down", () => {
+    it("returns 200 stub for valid UP/DOWN payload", async () => {
+      const res = await request(app)
+        .post("/api/bets/up-down")
+        .send({ address: VALID_ADDRESS, amount: 10, side: "UP" });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        success: true,
+        message: "Bet recorded (stub)",
+      });
+    });
+
+    it("returns 400 when required fields are missing", async () => {
+      const res = await request(app)
+        .post("/api/bets/up-down")
+        .send({ address: VALID_ADDRESS, amount: 10 });
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBeUndefined();
+      expect(res.body.message).toBeDefined();
+    });
+  });
+
+  describe("POST /api/bets/precision", () => {
+    it("returns 200 stub for valid Precision payload", async () => {
+      const res = await request(app)
+        .post("/api/bets/precision")
+        .send({ address: VALID_ADDRESS, amount: 5, predictedPrice: 0.12 });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        success: true,
+        message: "Bet recorded (stub)",
+      });
+    });
+
+    it("returns 400 when predictedPrice is missing", async () => {
+      const res = await request(app)
+        .post("/api/bets/precision")
+        .send({ address: VALID_ADDRESS, amount: 5 });
+
+      expect(res.status).toBe(400);
+      expect(res.body.message).toBeDefined();
+    });
+  });
+});

--- a/src/tests/round.service.active.spec.ts
+++ b/src/tests/round.service.active.spec.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from "@jest/globals";
+import { RoundMode } from "@tevalabs/xelma-bindings";
+
+const mockGetActiveRound = jest.fn();
+const mockFindMany = jest.fn();
+
+jest.mock("../services/soroban.service", () => ({
+  __esModule: true,
+  default: {
+    getActiveRound: (...args: any[]) => mockGetActiveRound(...args),
+    isReady: jest.fn().mockReturnValue(true),
+  },
+}));
+
+jest.mock("../lib/prisma", () => ({
+  prisma: {
+    round: {
+      findMany: (...args: any[]) => mockFindMany(...args),
+    },
+  },
+}));
+
+jest.mock("../config", () => ({
+  __esModule: true,
+  default: {
+    app: { roundsMockMode: false },
+  },
+}));
+
+describe("RoundService.getActiveRoundsWithFallback", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockGetActiveRound.mockReset();
+    mockFindMany.mockReset();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns soroban round when chain data is available", async () => {
+    mockGetActiveRound.mockResolvedValueOnce({
+      round_id: BigInt(9),
+      mode: RoundMode.UpDown,
+      price_start: BigInt(12000),
+      pool_up: BigInt(10_000_000),
+      pool_down: BigInt(5_000_000),
+      start_ledger: 1,
+      bet_end_ledger: 2,
+      end_ledger: 3,
+    });
+
+    const { default: roundService } = await import("../services/round.service");
+    const result = await roundService.getActiveRoundsWithFallback();
+
+    expect(result.source).toBe("soroban");
+    expect(result.rounds[0].sorobanRoundId).toBe("9");
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it("falls back to database when soroban returns null", async () => {
+    mockGetActiveRound.mockResolvedValueOnce(null);
+    mockFindMany.mockResolvedValueOnce([
+      {
+        id: "db-round-1",
+        mode: "UP_DOWN",
+        status: "ACTIVE",
+        startPrice: 0.5,
+      },
+    ]);
+
+    const { default: roundService } = await import("../services/round.service");
+    const result = await roundService.getActiveRoundsWithFallback();
+
+    expect(result.source).toBe("database");
+    expect(result.rounds[0].id).toBe("db-round-1");
+    expect(result.rounds[0].source).toBe("database");
+  });
+});

--- a/src/tests/rounds-active.routes.spec.ts
+++ b/src/tests/rounds-active.routes.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import request from "supertest";
+import { Express } from "express";
+import { createApp } from "../index";
+
+const mockGetActiveRoundsWithFallback = jest.fn();
+
+jest.mock("../services/round.service", () => ({
+  __esModule: true,
+  default: {
+    startRound: jest.fn(),
+    getRound: jest.fn(),
+    getActiveRoundsWithFallback: (...args: any[]) =>
+      mockGetActiveRoundsWithFallback(...args),
+  },
+}));
+
+jest.mock("../services/resolution.service", () => ({
+  __esModule: true,
+  default: {
+    resolveRound: jest.fn(),
+  },
+}));
+
+jest.mock("../middleware/rateLimiter.middleware", () => ({
+  challengeRateLimiter: (_req: any, _res: any, next: any) => next(),
+  connectRateLimiter: (_req: any, _res: any, next: any) => next(),
+  authRateLimiter: (_req: any, _res: any, next: any) => next(),
+  chatMessageRateLimiter: (_req: any, _res: any, next: any) => next(),
+  adminRoundRateLimiter: (_req: any, _res: any, next: any) => next(),
+  oracleResolveRateLimiter: (_req: any, _res: any, next: any) => next(),
+  predictionRateLimiter: (_req: any, _res: any, next: any) => next(),
+}));
+
+describe("Rounds Routes - active round sourcing", () => {
+  let app: Express;
+
+  beforeEach(() => {
+    app = createApp();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("GET /api/rounds/active returns soroban-sourced round", async () => {
+    mockGetActiveRoundsWithFallback.mockResolvedValueOnce({
+      source: "soroban",
+      rounds: [
+        {
+          id: "soroban-1",
+          sorobanRoundId: "1",
+          mode: "UP_DOWN",
+          status: "ACTIVE",
+          startPrice: 0.12,
+          poolUp: 1,
+          poolDown: 2,
+          isSoroban: true,
+          source: "soroban",
+        },
+      ],
+    });
+
+    const res = await request(app).get("/api/rounds/active");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      success: true,
+      source: "soroban",
+      rounds: [
+        {
+          id: "soroban-1",
+          sorobanRoundId: "1",
+          mode: "UP_DOWN",
+          status: "ACTIVE",
+          startPrice: 0.12,
+          poolUp: 1,
+          poolDown: 2,
+          isSoroban: true,
+          source: "soroban",
+        },
+      ],
+    });
+  });
+
+  it("GET /api/rounds/active is registered before /:id", async () => {
+    mockGetActiveRoundsWithFallback.mockResolvedValueOnce({
+      source: "none",
+      rounds: [],
+    });
+
+    const res = await request(app).get("/api/rounds/active");
+
+    expect(res.status).toBe(200);
+    expect(mockGetActiveRoundsWithFallback).toHaveBeenCalled();
+  });
+});

--- a/src/tests/soroban-round.mapper.spec.ts
+++ b/src/tests/soroban-round.mapper.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "@jest/globals";
+import { RoundMode } from "@tevalabs/xelma-bindings";
+import { mapSorobanActiveRound } from "../utils/soroban-round.mapper";
+
+describe("mapSorobanActiveRound", () => {
+  it("maps UP/DOWN round fields to API shape", () => {
+    const mapped = mapSorobanActiveRound({
+      round_id: BigInt(42),
+      mode: RoundMode.UpDown,
+      price_start: BigInt(12345),
+      pool_up: BigInt(50_000_000),
+      pool_down: BigInt(25_000_000),
+      start_ledger: 1000,
+      bet_end_ledger: 1100,
+      end_ledger: 1200,
+    });
+
+    expect(mapped).toEqual({
+      id: "soroban-42",
+      sorobanRoundId: "42",
+      mode: "UP_DOWN",
+      status: "ACTIVE",
+      startPrice: 1.2345,
+      poolUp: 5,
+      poolDown: 2.5,
+      startLedger: 1000,
+      betEndLedger: 1100,
+      endLedger: 1200,
+      isSoroban: true,
+      source: "soroban",
+    });
+  });
+
+  it("maps Precision mode to LEGENDS", () => {
+    const mapped = mapSorobanActiveRound({
+      round_id: 7,
+      mode: RoundMode.Precision,
+      price_start: 10000,
+      pool_up: 0,
+      pool_down: 0,
+      start_ledger: 1,
+      bet_end_ledger: 2,
+      end_ledger: 3,
+    });
+
+    expect(mapped.mode).toBe("LEGENDS");
+    expect(mapped.startPrice).toBe(1);
+  });
+});

--- a/src/utils/soroban-round.mapper.ts
+++ b/src/utils/soroban-round.mapper.ts
@@ -1,0 +1,56 @@
+import type { Round as SorobanRound } from "@tevalabs/xelma-bindings";
+import { RoundMode } from "@tevalabs/xelma-bindings";
+
+const PRICE_SCALE = 10_000;
+const STROOP_SCALE = 10_000_000;
+
+export type ActiveRoundSource = "soroban" | "database" | "none";
+
+export interface MappedActiveRound {
+  id: string;
+  sorobanRoundId: string;
+  mode: "UP_DOWN" | "LEGENDS";
+  status: "ACTIVE";
+  startPrice: number;
+  poolUp: number;
+  poolDown: number;
+  startLedger: number;
+  betEndLedger: number;
+  endLedger: number;
+  isSoroban: true;
+  source: "soroban";
+}
+
+function toNumber(value: bigint | number | string): number {
+  if (typeof value === "number") return value;
+  if (typeof value === "bigint") return Number(value);
+  return Number(value);
+}
+
+export function mapSorobanActiveRound(round: SorobanRound): MappedActiveRound {
+  const roundId = toNumber(round.round_id);
+  const mode =
+    round.mode === RoundMode.Precision || round.mode === 1 ? "LEGENDS" : "UP_DOWN";
+
+  return {
+    id: `soroban-${roundId}`,
+    sorobanRoundId: String(roundId),
+    mode,
+    status: "ACTIVE",
+    startPrice: toNumber(round.price_start) / PRICE_SCALE,
+    poolUp: toNumber(round.pool_up) / STROOP_SCALE,
+    poolDown: toNumber(round.pool_down) / STROOP_SCALE,
+    startLedger: Number(round.start_ledger),
+    betEndLedger: Number(round.bet_end_ledger),
+    endLedger: Number(round.end_ledger),
+    isSoroban: true,
+    source: "soroban",
+  };
+}
+
+export function mapDatabaseActiveRound(round: Record<string, unknown>): Record<string, unknown> {
+  return {
+    ...round,
+    source: "database" as const,
+  };
+}


### PR DESCRIPTION
## Summary
- Add hackathon stub bet endpoints for UP/DOWN and Precision modes so the frontend can complete bet UX before Soroban write bindings are wired.
- Source active round state from the Xelma Soroban contract via `get_active_round()`, with database fallback when RPC is unavailable or `ROUNDS_MOCK_MODE=true`.

## Changes

### Task 1 — Bet stub API
- `POST /api/bets/up-down` accepts `{ address, amount, side }` (`UP` | `DOWN`)
- `POST /api/bets/precision` accepts `{ address, amount, predictedPrice }`
- Returns `{ success: true, message: "Bet recorded (stub)" }` on valid input
- Zod validation returns 400 JSON errors for missing/invalid fields
- No on-chain execution; TODO comments mark future `@tevalabs/xelma-bindings` integration

### Task 2 — On-chain active rounds
- `GET /api/rounds/active` prefers Soroban `get_active_round()` in non-mock mode
- Maps contract `Round` fields to API shape (price, pools, ledgers, mode, `sorobanRoundId`)
- Falls back to Prisma active rounds when RPC fails or returns no round
- `ROUNDS_MOCK_MODE=true` forces database-only reads for local development
- Soroban service supports read-only initialization (contract ID + RPC URL only)
- Fixed route ordering so `/active` is not captured by `/:id`


Closes #220 
Closes #223 