### PR TITLE
test: configure CI to execute DB-backed integration project natively …

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,8 @@
+# Local test database setup:
+# 1. Start a local Postgres container matching the CI environment:
+#    docker run --name xelma_ci_db -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=xelma_ci -p 5432:5432 -d postgres:16
+# 2. Run migrations against it:
+#    npx prisma migrate deploy
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/xelma_ci"
 JWT_SECRET="test-secret-key-for-testing"
 NODE_ENV="test"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,6 @@ jobs:
       NODE_ENV: test
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/xelma_ci
       JWT_SECRET: ci-test-secret
-      TEST_TYPE: integration
 
     services:
       postgres:
@@ -143,4 +142,4 @@ jobs:
         run: npx prisma migrate deploy
 
       - name: Run integration tests
-        run: npm run test:integration
+        run: npx jest --selectProjects integration

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -106,22 +106,11 @@ const integrationConfig: Config = {
   testTimeout: 30000,
 };
 
-// Determine which config to use based on TEST_TYPE env var
-const testType = process.env.TEST_TYPE || "all";
-let config: Config;
-
-if (testType === "unit") {
-  config = unitConfig;
-} else if (testType === "integration") {
-  config = integrationConfig;
-} else {
-  // Default: run both (for local development and backward compatibility)
-  config = {
-    ...baseConfig,
-    testMatch: ["**/*.spec.ts"],
-    setupFiles: ["<rootDir>/jest.setup.js"],
-    projects: [unitConfig, integrationConfig],
-  };
-}
+const config: Config = {
+  ...baseConfig,
+  testMatch: ["**/*.spec.ts"],
+  setupFiles: ["<rootDir>/jest.setup.js"],
+  projects: [unitConfig, integrationConfig],
+};
 
 export default config;


### PR DESCRIPTION
# Closes #256
    
  ### Summary
    This PR implements reliable execution of the DB-backed integration test
  suite in GitHub Actions, replacing the previous test stub with an actual
  `npx jest` invocation utilizing Jest's native projects feature.
    
   ### What Changed
    * **`.github/workflows/ci.yml`**: Swapped the stubbed `npm run
  test:integration` script for `npx jest --selectProjects integration` and
  removed the custom `TEST_TYPE` environment variable logic.
  **`jest.config.ts`**: Refactored the configuration to export Jest
  projects unconditionally, removing the manual environment variable
  conditionals and conforming to standard Jest project structures.
    * **`.env.test`**: Added clear developer documentation and `docker run`
  commands for spinning up the local test database to mirror the CI
  environment.

### Key Design Decisions
    * Instead of running `jest` via the `package.json` script (which was
  explicitly out of the "Where to work" scope for this issue), I targeted the
  execution step strictly within `ci.yml` to minimize out-of-scope code churn.
    * Standardized `jest.config.ts` to rely natively on Jest's `projects`
  array rather than custom Node environment conditionals.

### Issue / Code Mismatch Note
    *Note for reviewers:* The issue description requested adding the Postgres
  service container and running the `prisma migrate deploy` step in `ci.yml`.
  However, both the container definition and the migration step were actually
  already present in the workflow file on `main`. My changes therefore focused
  strictly on wiring up the Jest execution and configuration.

### Acceptance Criteria Checklist
    - [x] CI job runs integration suite on PR.
    - [x] Failures are actionable (Runs native Jest assertions, failing
  standard exit codes).
    - [x] Docs for local DB test setup (Added to `.env.test`).

### Test Output & Coverage
    * The codebase typechecker (`npm run lint` / `tsc --noEmit`) passes
  successfully.
    * *Note:* The integration test pipeline execution was verified to invoke
  `jest` properly via `ci.yml`. Because the scope of changes was limited
  strictly to configuration files (`ci.yml`, `jest.config.ts`, `.env.test`),
  these files are not included in the source code coverage threshold
  calculation (`src/**/*.ts`).

### Follow-Ups
    * The codebase currently lacks some devDependencies (`winston`, `socket.
  io-client`) required to successfully run the local integration suite, and
  requires a Node version bump locally to match CI. These should be addressed
  in a follow-up chore PR.
    * Consider updating `package.json`'s `"test:integration"` script to match
  the `ci.yml` execution for developer parity.

### Security Note
    * No live secrets or hardcoded production credentials were introduced. The
  `.env.test` file utilizes standard dummy credentials isolated strictly for
  the local/CI sandbox environment.