### PR TITLE
fix: replace hardcoded CORS with env-driven production allowlist in app.ts

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -8,11 +8,19 @@ import statsRoutes from './routes/stats';
 import roundsRoutes from './routes/rounds';
 import leaderboardRoutes from './routes/leaderboard';
 import { apiRateLimiter, writeRateLimiter } from './middleware/rateLimiter';
+import { getHttpCorsOrigins } from './utils/cors';
 
 const app: Application = express();
 
 app.use(express.json());
-app.use(cors({ origin: true }));
+app.use(
+  cors({
+    origin: getHttpCorsOrigins(),
+    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'Idempotency-Key'],
+    credentials: true,
+  })
+);
 app.use(helmet());
 app.use(morgan('combined'));
 


### PR DESCRIPTION
## PR: Add CORS production allowlist for hackathon and full apps

**Close #281**

### Summary

Replace the hardcoded permissive `cors({ origin: true })` in `src/app.ts` with the env-driven origin allowlist via `getHttpCorsOrigins()` from `src/utils/cors.ts`. This brings `src/app.ts` (used by `src/server.ts`) in line with the CORS policy already enforced by `src/index.ts`.

### Changes

| File | Change |
|---|---|
| `src/app.ts` | Replaced `cors({ origin: true })` with `getHttpCorsOrigins()` and explicit CORS config matching `src/index.ts` |

### Behavior

| Environment | `CLIENT_URL` set? | Behavior |
|---|---|---|
| `development` | No | Allows all origins (permissive) |
| `development` | Yes | Allows only `CLIENT_URL` + `ALLOWED_ORIGINS` |
| `production` | Yes | Allows only `CLIENT_URL` + `ALLOWED_ORIGINS` |
| `production` | No | Throws at startup (CLIENT_URL required) |

### Why this matters

Open CORS (`origin: true`) is fine for hackathon demos but unsafe for deployed environments. Production now enforces proper browser origin policy.

### Acceptance criteria

- ✅ Production rejects unknown origins
- ✅ Local dev remains easy (permissive when `CLIENT_URL` is unset)
- ✅ Deployed API enforces proper browser origin policy

### Testing

- `src/tests/http-cors.spec.ts` — all passing
- `tsc --noEmit` — clean, no type errors
- No new dependencies or breaking changes
