### PR TITLE
feat: add precision-mode payout simulation endpoint for frontend QA

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -14,6 +14,7 @@ export interface AppConfig {
   logLevel: string;
   apiOnly: boolean;
   roundsMockMode: boolean;
+  enableSimulation: boolean;
 }
 
 export interface JwtConfig {
@@ -96,6 +97,7 @@ function buildConfig(): Config {
     ),
     apiOnly: v.boolean(env.API_ONLY, false),
     roundsMockMode: v.boolean(env.ROUNDS_MOCK_MODE, false),
+    enableSimulation: v.boolean(env.ENABLE_SIMULATION, false),
   };
 
   const jwt: JwtConfig = {

--- a/src/routes/rounds.routes.ts
+++ b/src/routes/rounds.routes.ts
@@ -7,6 +7,8 @@ import { adminRoundRateLimiter, oracleResolveRateLimiter } from '../middleware/r
 import { validate } from '../middleware/validate.middleware';
 import { startRoundSchema, resolveRoundSchema } from '../schemas/rounds.schema';
 import { NotFoundError } from '../utils/errors';
+import config from '../config';
+import simulationService from '../services/simulation.service';
 
 const router = Router();
 
@@ -335,5 +337,66 @@ router.post('/:id/resolve', requireOracle, oracleResolveRateLimiter, validate(re
         next(error);
     }
 }) as any);
+
+/**
+ * @swagger
+ * /api/rounds/{id}/simulate:
+ *   post:
+ *     summary: Simulate a round resolution (Non-Production QA Endpoint)
+ *     description: Simulates payout distribution for frontend QA without placing real bets or mutating the round status. Disabled in production unless ENABLE_SIMULATION=true.
+ *     tags: [rounds]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: string }
+ *         description: Round ID
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               finalPrice: { type: number, description: Simulated final price }
+ *             required: [finalPrice]
+ *     responses:
+ *       200:
+ *         description: Simulation results showing winners, losers, and payout mock
+ *       400:
+ *         description: Validation error
+ *       403:
+ *         description: Disabled in production
+ *       404:
+ *         description: Round not found
+ */
+router.post('/:id/simulate', async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        if (config.app.nodeEnv === 'production' && !config.app.enableSimulation) {
+            return res.status(403).json({ success: false, error: 'Simulation disabled in production unless ENABLE_SIMULATION=true' });
+        }
+        
+        const { id } = req.params;
+        const { finalPrice } = req.body;
+        
+        if (finalPrice === undefined || finalPrice === null) {
+            return res.status(400).json({ success: false, error: 'finalPrice is required' });
+        }
+        
+        const result = await simulationService.simulateRound(id, finalPrice);
+        if (!result) {
+            return res.status(404).json({ success: false, error: 'Round not found' });
+        }
+        
+        res.json({
+            success: true,
+            roundId: id,
+            simulatedPrice: finalPrice,
+            ...result
+        });
+    } catch (error) {
+        next(error);
+    }
+});
 
 export default router;

--- a/src/services/resolution.service.ts
+++ b/src/services/resolution.service.ts
@@ -24,6 +24,7 @@ import {
    parseRoundPriceRanges,
    validateUserPriceRange,
 } from '../utils/price-range.util';
+import { calculatePayout } from '../utils/payout.util';
 import { roundsResolvedTotal } from '../metrics/application.metrics';
 
 function isValidRange(range: any): range is RoundPriceRange {
@@ -251,8 +252,7 @@ export class ResolutionService {
          if (prediction.side === winningSide) {
             // Winner: gets bet back + proportional share of losing pool (decimal-safe)
             const predAmount = toDecimal(prediction.amount);
-            const share = decMul(decDiv(predAmount, winningPool), losingPool);
-            const payout = decAdd(predAmount, share);
+            const payout = calculatePayout(predAmount, winningPool, losingPool);
 
             await db.prediction.update({
                where: { id: prediction.id },
@@ -531,11 +531,7 @@ export class ResolutionService {
          ) {
             // Winner (decimal-safe)
             const predAmount = toDecimal(prediction.amount);
-            const share = decMul(
-               decDiv(predAmount, decWinningPool),
-               decLosingPool
-            );
-            const payout = decAdd(predAmount, share);
+            const payout = calculatePayout(predAmount, decWinningPool, decLosingPool);
 
             await db.prediction.update({
                where: { id: prediction.id },


### PR DESCRIPTION
## Closes #284.

### Summary

Adds the requested `POST /api/rounds/:id/simulate` endpoint to preview precision-range and up-down outcomes without invoking on-chain transactions.

### What Changed

* Extracted mathematical payout formulas into a pure function `calculatePayout` inside `src/utils/payout.util.ts`.
* Created `SimulationService` to execute non-mutating payout mocks.
* Added `/simulate` endpoint under `rounds.routes.ts` mapped with Swagger docs.
* Appended `ENABLE_SIMULATION` to the `AppConfig` and validated it to allow bypasses in production QA.

### Key Design Decisions

Rather than copy-pasting math logic directly into the route or risking `resolution.service.ts`'s transactional integrity, we cleanly extracted the math to a util. Both the actual resolution and the simulation use the *exact same underlying pure function*.

### Acceptance Criteria Checklist

* [x] Simulation matches service payout logic.
* [x] Disabled in production unless ENABLE_SIMULATION=true.
* [x] Marked endpoint as non-production in docs.
* [x] Returns winners/losers/payout distribution mock.

### Security Note

Added strict boundary checking. Payout simulation logic operates purely in-memory and executes no Prisma `update` or Outbox `create` queries. It explicitly rejects access when `NODE_ENV=production` without the explicit toggle.