### PR TITLE
Add Render deploy profile for hackathon start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ The repo has two Express applications. **New contributors should always use `npm
 |---|---|---|
 | `npm run dev` | `src/index.ts` | Everyday development — full backend, real DB, WebSocket, Soroban |
 | `npm run dev:hackathon` | `src/server.ts` | Demo without a database — mock data only |
+| `npm start` | `dist/server.js` (compiled `src/server.ts`) | **Default Render start command** — hackathon server (compiled) |
 
 See [docs/architecture.md](docs/architecture.md) for the full architecture decision, file map, migration plan, and a checklist for adding new routes.
 
@@ -1167,7 +1168,7 @@ At minimum, migration PRs should include:
 
 | Script | Description |
 |--------|-------------|
-| `npm start` | Run production server (requires build) |
+| `npm start` | Run hackathon/demo server (`dist/server.js`); this is the default Render start command (requires build) |
 | `npm run dev` | Start the **production** development server (`src/index.ts`) with hot-reload — use this for all feature work |
 | `npm run dev:hackathon` | Start the hackathon demo server (`src/server.ts`) — mock data only, no database required |
 | `npm run dev:render-parity` | Generate Prisma client, apply committed migrations, then start dev server |
@@ -1182,6 +1183,7 @@ At minimum, migration PRs should include:
 | `npm run prisma:migrate` | Run database migrations |
 | `npm run prisma:migrate:deploy` | Apply committed migrations without creating new migration files |
 | `npm run db:prepare` | Run Prisma generate and migrate deploy |
+| `node dist/index.js` | Run production full backend (Prisma, Soroban, schedulers, WebSocket); use this command in production Render profile |
 | `npm run docs:openapi` | Generate OpenAPI JSON spec to `docs/openapi.json` |
 | `npm run docs:verify` | Regenerate OpenAPI and verify required paths are documented (CI gate) |
 | `npm run docs:postman` | Export Postman collection |
@@ -2002,6 +2004,60 @@ npx prisma migrate status
 ```
 
 **Important:** Always test rollbacks in staging before applying to production. Database migrations are not automatically reversed; plan migrations to be backward-compatible when possible.
+
+---
+
+## Render Deployment
+
+The repository includes a [`render.yaml`](render.yaml) blueprint with two service profiles:
+
+### Profile 1: Hackathon Demo (`xelma-backend-hackathon`)
+
+| Setting | Value |
+|---|---|
+| **Start command** | `npm start` (runs `dist/server.js`) |
+| **Health check** | `GET /api/health` |
+| **Database** | Not required — set `DATA_MODE=mock` for in-process data |
+| **Plan** | Free tier sufficient |
+
+Minimal env vars needed (all others use sensible defaults):
+
+| Variable | Example | Purpose |
+|---|---|---|
+| `JWT_SECRET` | *(sync on Render)* | Signs JWT tokens |
+| `DATA_MODE` | `mock` | Use mock in-process data (no DB) |
+| `ENABLE_MULTIPLAYER_SOCIAL` | `true` | Enable chat / notifications |
+| `CLIENT_URL` | `https://your-app.onrender.com` | CORS origin |
+| `CONTRACT_ID` | *(sync on Render)* | Soroban contract address (optional for demo) |
+
+### Profile 2: Production Full Backend (`xelma-backend`)
+
+| Setting | Value |
+|---|---|
+| **Start command** | `node dist/index.js` |
+| **Health check** | `GET /health` |
+| **Database** | PostgreSQL required — migrations run automatically in build phase |
+| **Plan** | Starter or higher recommended |
+
+Required env vars:
+
+| Variable | Example / Purpose |
+|---|---|
+| `DATABASE_URL` | PostgreSQL connection string *(sync on Render)* |
+| `JWT_SECRET` | Strong random secret *(sync on Render)* |
+| `CLIENT_URL` | Frontend origin for CORS |
+| `SOROBAN_CONTRACT_ID` | Deployed prediction market contract *(sync on Render)* |
+| `SOROBAN_ADMIN_SECRET` | Stellar secret key for admin ops *(sync on Render)* |
+| `SOROBAN_ORACLE_SECRET` | Stellar secret key for oracle settlement *(sync on Render)* |
+
+### Choosing a Profile
+
+1. Go to **Dashboard > New > Blueprint** and connect your fork of this repo.
+2. Render reads `render.yaml` and lists both services. Uncheck the profile you do **not** want to deploy.
+3. For each selected service, fill in any `sync: false` env vars.
+4. Deploy. The service is reachable at `https://<service-name>.onrender.com:<PORT>`.
+
+> **Port note**: The server listens on the port defined by the `PORT` env var (default `3000`). Render automatically sets `PORT` in the runtime environment.
 
 ---
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,12 +1,62 @@
+# Render Blueprint — https://render.com/docs/blueprint-spec
+#
+# Two profiles:
+#   1. xelma-backend-hackathon  – demo server, no database required (default npm start)
+#   2. xelma-backend            – production full backend with Prisma, Soroban, schedulers
+#
+# Pick one when creating the Render service.  The "Hackathon" profile is the
+# simpler option for quick demos; the "Production" profile matches the full
+# runtime described in the README.
+
 services:
+  # ── Hackathon Demo ──────────────────────────────────────────────────────
+  # Runs dist/server.js (src/server.ts → src/app.ts) with mock-data support.
+  # No PostgreSQL migrations required — DATA_MODE=mock uses in-process data.
   - type: web
-    name: xelma-backend
+    name: xelma-backend-hackathon
     env: node
     region: oregon
     plan: free
     nodeVersion: "22"
-    buildCommand: npm ci && npm run build && npx prisma generate && npx prisma migrate deploy
+    buildCommand: npm ci && npm run build
     startCommand: npm start
+    healthCheckPath: /api/health
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: PORT
+        value: "3000"
+      - key: JWT_SECRET
+        sync: false
+      - key: DATA_MODE
+        value: mock
+      - key: ENABLE_MULTIPLAYER_SOCIAL
+        value: "true"
+      - key: CLIENT_URL
+        sync: false
+      - key: COINGECKO_API_URL
+        value: https://api.coingecko.com/api/v3/simple/price?ids=stellar&vs_currencies=usd
+      - key: STELLAR_RPC_URL
+        value: https://soroban-testnet.stellar.org
+      - key: CONTRACT_ID
+        sync: false
+
+  # ── Production (Full Backend) ───────────────────────────────────────────
+  # Runs dist/index.js (src/index.ts) – the complete application with
+  # Prisma ORM, Soroban contract integration, cron schedulers, price oracle,
+  # WebSocket broadcasting, and all API routes including admin/monitoring.
+  #
+  # Requires a PostgreSQL database.  Migrations are applied automatically
+  # during the build phase.
+  - type: web
+    name: xelma-backend
+    env: node
+    region: oregon
+    plan: starter
+    nodeVersion: "22"
+    buildCommand: npm ci && npm run build && npx prisma generate && npx prisma migrate deploy
+    startCommand: node dist/index.js
+    healthCheckPath: /health
     envVars:
       - key: NODE_ENV
         value: production
@@ -32,3 +82,17 @@ services:
         sync: false
       - key: SOROBAN_ORACLE_SECRET
         sync: false
+      - key: ROUND_SCHEDULER_ENABLED
+        value: "false"
+      - key: ROUND_SCHEDULER_MODE
+        value: UP_DOWN
+      - key: API_ONLY
+        value: "false"
+      - key: ORACLE_POLLING_INTERVAL_MS
+        value: "10000"
+      - key: ORACLE_REQUEST_TIMEOUT_MS
+        value: "5000"
+      - key: ORACLE_MAX_RETRIES
+        value: "3"
+      - key: ORACLE_STALENESS_THRESHOLD_MS
+        value: "60000"


### PR DESCRIPTION
## Summary

Update deployment config to support hackathon `node dist/server.js` vs full backend start modes with env templates.

## Why this matters

Current deploy docs assume full backend while default repo scripts target hackathon server. The `render.yaml` now has two explicit profiles so deployers can pick the right one.

## Changes

### `render.yaml`
- Added **`xelma-backend-hackathon`** service profile — runs `npm start` (`dist/server.js`), health check at `/api/health`, no DB required, free-tier friendly
- Renamed original config to **`xelma-backend`** (production full backend) — runs `node dist/index.js`, health check at `/health`, includes Prisma migrations in build, starter plan recommended
- Both profiles include appropriate env var groups with documentation comments

### `README.md`
- Added **Render Deployment** section documenting both profiles with required env vars, health check paths, and setup instructions
- Updated entrypoints table to include `npm start` (hackathon server)
- Clarified scripts table entries for `npm start` and `node dist/index.js`

## Acceptance criteria

- [x] Render config supports chosen default mode (two profiles available)
- [x] Deploy instructions are reproducible (step-by-step in README)
- [x] Health check paths and port notes documented

Closes #338