### PR TITLE
Add bet submission audit event schema for analytics

### DIFF
--- a/src/services/bet-audit.service.ts
+++ b/src/services/bet-audit.service.ts
@@ -1,0 +1,184 @@
+/**
+ * Bet Audit Service
+ *
+ * Provides structured audit events whenever a bet is accepted.
+ * Designed for analytics, debugging, and future on-chain migration.
+ *
+ * Event schema (same across all storage modes):
+ * {
+ *   event:    "BET_ACCEPTED",
+ *   roundId:  string | undefined,  // enriched asynchronously from active round
+ *   address:  string,               // Stellar wallet address
+ *   amount:   number,               // bet amount
+ *   side?:    "UP" | "DOWN",       // only for UP_DOWN mode
+ *   mode:     "UP_DOWN" | "PRECISION",
+ *   result:   string,               // "stub" | "on-chain-success"
+ *   txHash?:  string,               // present for on-chain bets
+ *   createdAt: string               // ISO-8601 timestamp
+ * }
+ *
+ * Storage modes (controlled by BET_AUDIT_STORAGE env var):
+ *   - "memory"   (default / hackathon)  – events held in an in-memory array
+ *   - "database" (full mode)            – persisted to the AuditLog table
+ *
+ * Future on-chain migration:
+ *   The BetAuditEvent schema maps 1:1 to a future on-chain event. Each field
+ *   can be serialised as a Solidity/ Soroban event parameter. The `event`
+ *   discriminator ("BET_ACCEPTED") matches the on-chain event name.
+ *
+ * Safety / redaction:
+ *   No private keys, tokens, or sensitive wallet data are logged.
+ *   The schema only contains public bet metadata.
+ */
+
+import logger from "../utils/logger";
+import { prisma } from "../lib/prisma";
+import { GameMode } from "@prisma/client";
+
+export interface BetAuditEvent {
+  event: "BET_ACCEPTED";
+  roundId?: string;
+  address: string;
+  amount: number;
+  side?: "UP" | "DOWN";
+  mode: "UP_DOWN" | "PRECISION";
+  result: string;
+  txHash?: string;
+  createdAt: string;
+}
+
+export interface BetAuditParams {
+  address: string;
+  amount: number;
+  side?: "UP" | "DOWN";
+  mode: "UP_DOWN" | "PRECISION";
+  result: string;
+  txHash?: string;
+}
+
+class BetAuditService {
+  private events: BetAuditEvent[] = [];
+
+  get storageMode(): "memory" | "database" {
+    const mode = process.env.BET_AUDIT_STORAGE;
+    if (mode === "database") return "database";
+    return "memory";
+  }
+
+  /**
+   * Emit a BET_ACCEPTED audit event.
+   *
+   * The event is recorded synchronously in the in-memory store so callers
+   * can inspect it immediately. Round enrichment and database persistence
+   * happen asynchronously (fire-and-forget) to avoid blocking the bet flow.
+   *
+   * Events are emitted only for successfully accepted bets (never for
+   * rejected / failed bets).
+   *
+   * Intended analytics usage:
+   *   - Count total accepted bets per round / address / mode
+   *   - Track bet volume and side distribution over time
+   *   - Debug bet acceptance failures by correlating with server logs
+   *   - Replay events into an analytical store (e.g. ClickHouse, BigQuery)
+   *
+   * Future on-chain compatibility:
+   *   The returned BetAuditEvent can be serialised as an on-chain event
+   *   (e.g. Soroban event topic / data, or EVM log). The `event` field
+   *   serves as the event name / topic discriminator.
+   */
+  emitBetAccepted(params: BetAuditParams): BetAuditEvent {
+    const event: BetAuditEvent = {
+      event: "BET_ACCEPTED",
+      roundId: undefined,
+      address: params.address,
+      amount: params.amount,
+      side: params.side,
+      mode: params.mode,
+      result: params.result,
+      txHash: params.txHash,
+      createdAt: new Date().toISOString(),
+    };
+
+    this.events.push(event);
+
+    logger.info("Bet accepted", { audit: true, ...event });
+
+    void this.enrichAndPersist(event, params);
+
+    return event;
+  }
+
+  /**
+   * Asynchronously enrich the event with the active round ID and persist
+   * to the database when database mode is enabled.
+   *
+   * Both steps are best-effort and fire-and-forget – neither will throw
+   * or block the caller.
+   */
+  private async enrichAndPersist(
+    event: BetAuditEvent,
+    params: BetAuditParams,
+  ): Promise<void> {
+    try {
+      const gameMode =
+        params.mode === "UP_DOWN" ? GameMode.UP_DOWN : GameMode.LEGENDS;
+      const round = await prisma.round.findFirst({
+        where: { mode: gameMode, status: "ACTIVE" },
+        orderBy: { startTime: "desc" },
+        select: { id: true },
+      });
+      if (round) {
+        event.roundId = round.id;
+      }
+    } catch {
+      // Round lookup is best-effort; silent fail
+    }
+
+    if (this.storageMode === "database") {
+      try {
+        await this.persistToDatabase(event);
+      } catch (error) {
+        logger.error("Failed to persist bet audit event to database", {
+          error: error instanceof Error ? error.message : "Unknown error",
+          eventType: event.event,
+        });
+      }
+    }
+  }
+
+  private async persistToDatabase(event: BetAuditEvent): Promise<void> {
+    await prisma.auditLog.create({
+      data: {
+        eventType: event.event,
+        severity: "info",
+        message: `Bet accepted: ${event.mode}${event.side ? " " + event.side : ""}`,
+        outcome: "success",
+        actorType: "user",
+        walletAddress: event.address,
+        resourceType: "bet",
+        resourceId: event.roundId,
+        metadata: {
+          amount: event.amount,
+          side: event.side,
+          mode: event.mode,
+          result: event.result,
+          txHash: event.txHash,
+        } as any,
+        timestamp: new Date(event.createdAt),
+      },
+    });
+  }
+
+  /** Return a copy of all in-memory events (for testing / analytics). */
+  getEvents(): BetAuditEvent[] {
+    return [...this.events];
+  }
+
+  /** Clear all in-memory events (for test isolation). */
+  clear(): void {
+    this.events = [];
+  }
+}
+
+export const betAuditService = new BetAuditService();
+export default betAuditService;

--- a/src/services/bet.service.ts
+++ b/src/services/bet.service.ts
@@ -1,5 +1,6 @@
 import logger from "../utils/logger";
 import sorobanService from "./soroban.service";
+import betAuditService from "./bet-audit.service";
 
 export interface UpDownBetInput {
   address: string;
@@ -21,26 +22,51 @@ export class BetService {
     input: UpDownBetInput,
     idempotencyKey?: string
   ): Promise<{ state: string; txHash?: string }> {
+    let result: { state: string; txHash?: string };
+
     if (process.env.BET_STUB_MODE === "true") {
       logger.info("UP/DOWN bet stub recorded", { ...input, idempotencyKey });
-      return { state: "stub" };
+      result = { state: "stub" };
+    } else {
+      logger.info("Placing UP/DOWN bet on-chain", { ...input, idempotencyKey });
+      result = await sorobanService.placeBet(input.address, input.amount, input.side);
     }
-    
-    logger.info("Placing UP/DOWN bet on-chain", { ...input, idempotencyKey });
-    return await sorobanService.placeBet(input.address, input.amount, input.side);
+
+    betAuditService.emitBetAccepted({
+      address: input.address,
+      amount: input.amount,
+      side: input.side,
+      mode: "UP_DOWN",
+      result: result.state,
+      txHash: result.txHash,
+    });
+
+    return result;
   }
 
   async recordPrecisionBet(
     input: PrecisionBetInput,
     idempotencyKey?: string
   ): Promise<{ state: string; txHash?: string }> {
+    let result: { state: string; txHash?: string };
+
     if (process.env.BET_STUB_MODE === "true") {
       logger.info("Precision bet stub recorded", { ...input, idempotencyKey });
-      return { state: "stub" };
+      result = { state: "stub" };
+    } else {
+      logger.info("Placing Precision bet on-chain", { ...input, idempotencyKey });
+      result = await sorobanService.placePrecisionBet(input.address, input.amount, input.predictedPrice);
     }
-    
-    logger.info("Placing Precision bet on-chain", { ...input, idempotencyKey });
-    return await sorobanService.placePrecisionBet(input.address, input.amount, input.predictedPrice);
+
+    betAuditService.emitBetAccepted({
+      address: input.address,
+      amount: input.amount,
+      mode: "PRECISION",
+      result: result.state,
+      txHash: result.txHash,
+    });
+
+    return result;
   }
 }
 

--- a/src/tests/bet-audit.spec.ts
+++ b/src/tests/bet-audit.spec.ts
@@ -1,0 +1,470 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from "@jest/globals";
+import { betAuditService } from "../services/bet-audit.service";
+import betService from "../services/bet.service";
+
+// ----------------------------------------------------------------
+// Mocks
+// ----------------------------------------------------------------
+
+jest.mock("../services/soroban.service", () => ({
+  __esModule: true,
+  default: {
+    placeBet: jest.fn(),
+    placePrecisionBet: jest.fn(),
+  },
+}));
+
+jest.mock("../utils/logger", () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+jest.mock("../lib/prisma", () => ({
+  prisma: {
+    auditLog: {
+      create: jest.fn().mockResolvedValue({ id: "audit-123" }),
+    },
+  },
+}));
+
+import sorobanService from "../services/soroban.service";
+import logger from "../utils/logger";
+import { prisma } from "../lib/prisma";
+
+const mockAuditLogCreate = prisma.auditLog.create as any;
+
+const VALID_ADDRESS = "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890";
+
+// ================================================================
+// BetAuditService unit tests
+// ================================================================
+
+describe("BetAuditService", () => {
+  beforeEach(() => {
+    betAuditService.clear();
+    jest.clearAllMocks();
+  });
+
+  // --------------------------------------------------------------
+  // Test 3: Event schema contains required fields
+  // --------------------------------------------------------------
+  describe("event schema (test 3)", () => {
+    it("should contain all required fields for UP_DOWN bet", () => {
+      const event = betAuditService.emitBetAccepted({
+        address: VALID_ADDRESS,
+        amount: 100,
+        side: "UP",
+        mode: "UP_DOWN",
+        result: "stub",
+      });
+
+      expect(event.event).toBe("BET_ACCEPTED");
+      expect(event.roundId).toBeUndefined();
+      expect(event.address).toBe(VALID_ADDRESS);
+      expect(event.amount).toBe(100);
+      expect(event.side).toBe("UP");
+      expect(event.mode).toBe("UP_DOWN");
+      expect(event.result).toBe("stub");
+      expect(event.createdAt).toBeDefined();
+      expect(typeof event.createdAt).toBe("string");
+      expect(Date.parse(event.createdAt)).not.toBeNaN();
+    });
+
+    it("should create event for PRECISION mode without side", () => {
+      const event = betAuditService.emitBetAccepted({
+        address: VALID_ADDRESS,
+        amount: 50,
+        mode: "PRECISION",
+        result: "on-chain-success",
+        txHash: "0xabc123",
+      });
+
+      expect(event.event).toBe("BET_ACCEPTED");
+      expect(event.mode).toBe("PRECISION");
+      expect(event.side).toBeUndefined();
+      expect(event.txHash).toBe("0xabc123");
+      expect(event.amount).toBe(50);
+    });
+
+    it("should generate a valid ISO-8601 timestamp", () => {
+      const before = Date.now();
+      const event = betAuditService.emitBetAccepted({
+        address: VALID_ADDRESS,
+        amount: 100,
+        side: "DOWN",
+        mode: "UP_DOWN",
+        result: "stub",
+      });
+      const after = Date.now();
+
+      const ts = Date.parse(event.createdAt);
+      expect(ts).not.toBeNaN();
+      expect(ts).toBeGreaterThanOrEqual(before);
+      expect(ts).toBeLessThanOrEqual(after);
+    });
+
+    it("should not contain sensitive data (secrets, tokens, keys)", () => {
+      const event = betAuditService.emitBetAccepted({
+        address: VALID_ADDRESS,
+        amount: 100,
+        side: "UP",
+        mode: "UP_DOWN",
+        result: "stub",
+      });
+
+      const json = JSON.stringify(event);
+      expect(json).not.toContain("secret");
+      expect(json).not.toContain("private_key");
+      expect(json).not.toContain("privateKey");
+      expect(json).not.toContain("token");
+      expect(json).not.toContain("password");
+      expect(json).not.toContain("jwt");
+    });
+  });
+
+  // --------------------------------------------------------------
+  // Test 4a: Storage behavior – memory mode
+  // --------------------------------------------------------------
+  describe("storage - memory mode (test 4a)", () => {
+    it("should store event in memory and retrieve via getEvents", () => {
+      expect(betAuditService.getEvents()).toHaveLength(0);
+
+      betAuditService.emitBetAccepted({
+        address: VALID_ADDRESS,
+        amount: 100,
+        side: "UP",
+        mode: "UP_DOWN",
+        result: "stub",
+      });
+
+      const events = betAuditService.getEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].address).toBe(VALID_ADDRESS);
+    });
+
+    it("should accumulate multiple events", () => {
+      betAuditService.emitBetAccepted({
+        address: VALID_ADDRESS,
+        amount: 100,
+        side: "UP",
+        mode: "UP_DOWN",
+        result: "stub",
+      });
+
+      betAuditService.emitBetAccepted({
+        address: VALID_ADDRESS,
+        amount: 200,
+        side: "DOWN",
+        mode: "UP_DOWN",
+        result: "on-chain-success",
+        txHash: "0x456",
+      });
+
+      expect(betAuditService.getEvents()).toHaveLength(2);
+    });
+
+    it("should clear events when clear() is called", () => {
+      betAuditService.emitBetAccepted({
+        address: VALID_ADDRESS,
+        amount: 100,
+        side: "UP",
+        mode: "UP_DOWN",
+        result: "stub",
+      });
+
+      expect(betAuditService.getEvents()).toHaveLength(1);
+
+      betAuditService.clear();
+      expect(betAuditService.getEvents()).toHaveLength(0);
+    });
+
+    it("should return a defensive copy from getEvents", () => {
+      betAuditService.emitBetAccepted({
+        address: VALID_ADDRESS,
+        amount: 100,
+        side: "UP",
+        mode: "UP_DOWN",
+        result: "stub",
+      });
+
+      const events = betAuditService.getEvents();
+      (events as any).push("tamper");
+      expect(betAuditService.getEvents()).toHaveLength(1);
+    });
+  });
+
+  // --------------------------------------------------------------
+  // Test 4b: Storage behavior – database mode (when implemented)
+  // --------------------------------------------------------------
+  describe("storage - database mode (test 4b)", () => {
+    let originalStorage: string | undefined;
+
+    beforeEach(() => {
+      originalStorage = process.env.BET_AUDIT_STORAGE;
+      process.env.BET_AUDIT_STORAGE = "database";
+    });
+
+    afterEach(() => {
+      if (originalStorage !== undefined) {
+        process.env.BET_AUDIT_STORAGE = originalStorage;
+      } else {
+        delete process.env.BET_AUDIT_STORAGE;
+      }
+    });
+
+    it("should persist UP_DOWN bet to AuditLog table", async () => {
+      betAuditService.emitBetAccepted({
+        address: VALID_ADDRESS,
+        amount: 100,
+        side: "UP",
+        mode: "UP_DOWN",
+        result: "stub",
+      });
+
+      // Wait for the async enrichAndPersist to complete
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(mockAuditLogCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            eventType: "BET_ACCEPTED",
+            severity: "info",
+            message: "Bet accepted: UP_DOWN UP",
+            outcome: "success",
+            actorType: "user",
+            walletAddress: VALID_ADDRESS,
+            resourceType: "bet",
+            metadata: expect.objectContaining({
+              amount: 100,
+              side: "UP",
+              mode: "UP_DOWN",
+              result: "stub",
+            }),
+          }),
+        }),
+      );
+    });
+
+    it("should persist PRECISION bet to AuditLog table", async () => {
+      betAuditService.emitBetAccepted({
+        address: VALID_ADDRESS,
+        amount: 50,
+        mode: "PRECISION",
+        result: "on-chain-success",
+        txHash: "0xabc123",
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(mockAuditLogCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            eventType: "BET_ACCEPTED",
+            message: "Bet accepted: PRECISION",
+            metadata: expect.objectContaining({
+              amount: 50,
+              mode: "PRECISION",
+              result: "on-chain-success",
+              txHash: "0xabc123",
+            }),
+          }),
+        }),
+      );
+    });
+
+    it("should handle database errors gracefully", async () => {
+      mockAuditLogCreate.mockRejectedValue(
+        new Error("Database connection failed"),
+      );
+
+      betAuditService.emitBetAccepted({
+        address: VALID_ADDRESS,
+        amount: 100,
+        side: "UP",
+        mode: "UP_DOWN",
+        result: "stub",
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(logger.error).toHaveBeenCalledWith(
+        "Failed to persist bet audit event to database",
+        expect.objectContaining({
+          error: "Database connection failed",
+        }),
+      );
+    });
+  });
+
+  // --------------------------------------------------------------
+  // Storage mode selection
+  // --------------------------------------------------------------
+  describe("storage mode selection", () => {
+    afterEach(() => {
+      delete process.env.BET_AUDIT_STORAGE;
+    });
+
+    it('should default to "memory" when env var is not set', () => {
+      delete process.env.BET_AUDIT_STORAGE;
+      expect(betAuditService.storageMode).toBe("memory");
+    });
+
+    it('should return "database" when env var is set to "database"', () => {
+      process.env.BET_AUDIT_STORAGE = "database";
+      expect(betAuditService.storageMode).toBe("database");
+    });
+
+    it('should return "memory" for unknown env var values', () => {
+      process.env.BET_AUDIT_STORAGE = "unknown";
+      expect(betAuditService.storageMode).toBe("memory");
+    });
+  });
+});
+
+// ================================================================
+// BetService + BetAuditService integration tests
+// ================================================================
+
+describe("BetService + AuditService integration", () => {
+  beforeEach(() => {
+    betAuditService.clear();
+    jest.clearAllMocks();
+  });
+
+  // --------------------------------------------------------------
+  // Test 1: Accepted bet creates audit event
+  // --------------------------------------------------------------
+  describe("accepted bet creates audit event (test 1)", () => {
+    it("should emit audit event for UP/DOWN bet in stub mode", async () => {
+      process.env.BET_STUB_MODE = "true";
+
+      await betService.recordUpDownBet({
+        address: VALID_ADDRESS,
+        amount: 100,
+        side: "UP",
+      });
+
+      const events = betAuditService.getEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        event: "BET_ACCEPTED",
+        address: VALID_ADDRESS,
+        amount: 100,
+        side: "UP",
+        mode: "UP_DOWN",
+        result: "stub",
+      });
+    });
+
+    it("should emit audit event for UP/DOWN bet in on-chain mode", async () => {
+      process.env.BET_STUB_MODE = "false";
+      (sorobanService.placeBet as jest.Mock).mockResolvedValue({
+        state: "on-chain-success",
+        txHash: "0xtest123",
+      });
+
+      await betService.recordUpDownBet({
+        address: VALID_ADDRESS,
+        amount: 100,
+        side: "UP",
+      });
+
+      const events = betAuditService.getEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        event: "BET_ACCEPTED",
+        address: VALID_ADDRESS,
+        amount: 100,
+        side: "UP",
+        mode: "UP_DOWN",
+        result: "on-chain-success",
+        txHash: "0xtest123",
+      });
+    });
+
+    it("should emit audit event for PRECISION bet", async () => {
+      process.env.BET_STUB_MODE = "false";
+      (sorobanService.placePrecisionBet as jest.Mock).mockResolvedValue({
+        state: "on-chain-success",
+        txHash: "0xprecision",
+      });
+
+      await betService.recordPrecisionBet({
+        address: VALID_ADDRESS,
+        amount: 50,
+        predictedPrice: 0.12,
+      });
+
+      const events = betAuditService.getEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        event: "BET_ACCEPTED",
+        address: VALID_ADDRESS,
+        amount: 50,
+        mode: "PRECISION",
+        result: "on-chain-success",
+        txHash: "0xprecision",
+      });
+    });
+
+    it("should emit audit event for PRECISION bet in stub mode", async () => {
+      process.env.BET_STUB_MODE = "true";
+
+      await betService.recordPrecisionBet({
+        address: VALID_ADDRESS,
+        amount: 50,
+        predictedPrice: 0.12,
+      });
+
+      const events = betAuditService.getEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        event: "BET_ACCEPTED",
+        address: VALID_ADDRESS,
+        amount: 50,
+        mode: "PRECISION",
+        result: "stub",
+      });
+    });
+  });
+
+  // --------------------------------------------------------------
+  // Test 2: Failed bet does NOT create audit event
+  // --------------------------------------------------------------
+  describe("failed bet does not create audit event (test 2)", () => {
+    it("should not emit audit event when Soroban throws for UP/DOWN bet", async () => {
+      process.env.BET_STUB_MODE = "false";
+      (sorobanService.placeBet as jest.Mock).mockRejectedValue(
+        new Error("Soroban contract error: tx failed"),
+      );
+
+      await expect(
+        betService.recordUpDownBet({
+          address: VALID_ADDRESS,
+          amount: 100,
+          side: "UP",
+        }),
+      ).rejects.toThrow();
+
+      expect(betAuditService.getEvents()).toHaveLength(0);
+    });
+
+    it("should not emit audit event when Soroban throws for PRECISION bet", async () => {
+      process.env.BET_STUB_MODE = "false";
+      (sorobanService.placePrecisionBet as jest.Mock).mockRejectedValue(
+        new Error("Circuit breaker is open"),
+      );
+
+      await expect(
+        betService.recordPrecisionBet({
+          address: VALID_ADDRESS,
+          amount: 50,
+          predictedPrice: 0.12,
+        }),
+      ).rejects.toThrow();
+
+      expect(betAuditService.getEvents()).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
Closes #341

Summary:
Adds structured audit events for accepted bets to support analytics, debugging, and future on-chain migration.

Changes:

- Added BET_ACCEPTED audit event schema
- Integrated audit emission into bet acceptance flow
- Added structured fields:

  - roundId
  - address
  - amount
  - side
  - mode
  - result
  - timestamp

Storage:

- Added in-memory storage support for hackathon mode
- Added database persistence path where applicable

Safety:

- Added logging guidance
- Prevented sensitive data exposure in audit output

Tests:

Added coverage for:

- successful bet audit creation
- rejected bet without audit event
- schema validation
- storage behavior

Validation:

- Bet lifecycle is now traceable
- Existing betting behavior preserved
- Tests passing