### PR TITLE
feat: persist stub bet submissions to in-memory analytics store

### DIFF
--- a/src/data/bet-store.ts
+++ b/src/data/bet-store.ts
@@ -1,0 +1,112 @@
+export interface StoredBet {
+  address: string;
+  amount: number;
+  side?: 'UP' | 'DOWN';
+  predictedPrice?: number;
+  roundId: string;
+  timestamp: string;
+}
+
+export interface StoredRound {
+  id: string;
+  asset: string;
+  mode: 'updown' | 'precision';
+  status: 'live' | 'new';
+  startPrice: number;
+  poolUp: number;
+  poolDown: number;
+  totalPool: number;
+  predictionCount: number;
+  closesAt: string;
+}
+
+const MINUTES_FROM_NOW = (minutes: number): string =>
+  new Date(Date.now() + minutes * 60 * 1000).toISOString();
+
+const SEED_ROUNDS: StoredRound[] = [
+  {
+    id: 'btc-updown-live',
+    asset: 'BTC',
+    mode: 'updown',
+    status: 'live',
+    startPrice: 67420,
+    poolUp: 2800,
+    poolDown: 1400,
+    totalPool: 4200,
+    predictionCount: 0,
+    closesAt: MINUTES_FROM_NOW(3),
+  },
+  {
+    id: 'eth-precision-live',
+    asset: 'ETH',
+    mode: 'precision',
+    status: 'live',
+    startPrice: 3241,
+    poolUp: 0,
+    poolDown: 0,
+    totalPool: 1800,
+    predictionCount: 22,
+    closesAt: MINUTES_FROM_NOW(12),
+  },
+  {
+    id: 'xlm-updown-new',
+    asset: 'XLM',
+    mode: 'updown',
+    status: 'new',
+    startPrice: 0.2891,
+    poolUp: 200,
+    poolDown: 0,
+    totalPool: 200,
+    predictionCount: 0,
+    closesAt: MINUTES_FROM_NOW(20),
+  },
+];
+
+class BetStore {
+  private rounds: Map<string, StoredRound>;
+  private bets: StoredBet[] = [];
+  private totalBetsCount = 0;
+
+  constructor() {
+    this.rounds = new Map(SEED_ROUNDS.map(r => [r.id, { ...r }]));
+  }
+
+  addUpDownBet(roundId: string, address: string, amount: number, side: 'UP' | 'DOWN'): void {
+    const round = this.rounds.get(roundId);
+    if (!round || round.mode !== 'updown') return;
+
+    if (side === 'UP') round.poolUp += amount;
+    else round.poolDown += amount;
+    round.totalPool = round.poolUp + round.poolDown;
+
+    this.bets.push({ roundId, address, amount, side, timestamp: new Date().toISOString() });
+    this.totalBetsCount++;
+  }
+
+  addPrecisionBet(roundId: string, address: string, amount: number, predictedPrice: number): void {
+    const round = this.rounds.get(roundId);
+    if (!round || round.mode !== 'precision') return;
+
+    round.totalPool += amount;
+    round.predictionCount++;
+
+    this.bets.push({ roundId, address, amount, predictedPrice, timestamp: new Date().toISOString() });
+    this.totalBetsCount++;
+  }
+
+  getRounds(): StoredRound[] {
+    return Array.from(this.rounds.values());
+  }
+
+  getTotalBetsCount(): number {
+    return this.totalBetsCount;
+  }
+
+  getActiveRound(mode: 'updown' | 'precision'): StoredRound | undefined {
+    return Array.from(this.rounds.values()).find(
+      r => r.mode === mode && r.status === 'live'
+    );
+  }
+}
+
+export const betStore = new BetStore();

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -15,6 +15,19 @@ export type MockLeaderboardUser = {
   rankTitle: string;
 };
 
+export const mockLeaderboard: MockLeaderboardUser[] = [
+  { rank: 1, address: 'GBZX...9QRA', totalWins: 42, totalLosses: 8, winStreak: 9, xp: 18400, rankTitle: 'Oracle' },
+  { rank: 2, address: 'GDK4...2LXM', totalWins: 37, totalLosses: 10, winStreak: 6, xp: 15950, rankTitle: 'Market Sage' },
+  { rank: 3, address: 'GAV7...8PQN', totalWins: 35, totalLosses: 13, winStreak: 4, xp: 14820, rankTitle: 'Trend Master' },
+  { rank: 4, address: 'GC9M...5VTE', totalWins: 31, totalLosses: 14, winStreak: 3, xp: 13210, rankTitle: 'Signal Hunter' },
+  { rank: 5, address: 'GCB2...7KDW', totalWins: 29, totalLosses: 15, winStreak: 5, xp: 12490, rankTitle: 'Pool Climber' },
+  { rank: 6, address: 'GDPT...4NLA', totalWins: 26, totalLosses: 16, winStreak: 2, xp: 11160, rankTitle: 'Price Reader' },
+  { rank: 7, address: 'GB7N...6XHF', totalWins: 24, totalLosses: 18, winStreak: 1, xp: 10240, rankTitle: 'Streak Keeper' },
+  { rank: 8, address: 'GCR8...3MLB', totalWins: 22, totalLosses: 20, winStreak: 2, xp: 9480, rankTitle: 'Chart Scout' },
+  { rank: 9, address: 'GAF5...1ZQH', totalWins: 19, totalLosses: 17, winStreak: 1, xp: 8360, rankTitle: 'Breakout Seeker' },
+  { rank: 10, address: 'GDT6...8RCV', totalWins: 17, totalLosses: 19, winStreak: 0, xp: 7540, rankTitle: 'Rookie Prophet' },
+];
+
 // Async functions calling the new Prisma repository
 export const getMockRounds = async (): Promise<MockPredictionRound[]> => {
   const rounds = await mockDataRepository.getRounds();

--- a/src/repositories/in-memory.repositories.ts
+++ b/src/repositories/in-memory.repositories.ts
@@ -1,8 +1,5 @@
-import {
-  getMockRounds,
-  mockLeaderboard,
-  MOCK_PLATFORM_STATS,
-} from "../data/mockData";
+import { betStore, StoredRound } from "../data/bet-store";
+import { mockLeaderboard, MOCK_PLATFORM_STATS } from "../data/mockData";
 import {
   LeaderboardRepository,
   Repositories,
@@ -11,14 +8,30 @@ import {
 } from "./interfaces";
 import { PlatformStats } from "../services/stats.service";
 
+function storedRoundToMockPredictionRound(r: StoredRound) {
+  if (r.mode === 'updown') {
+    return {
+      id: r.id, asset: r.asset, mode: 'updown' as const, status: r.status as 'live' | 'new',
+      startPrice: r.startPrice, poolUp: r.poolUp, poolDown: r.poolDown, closesAt: r.closesAt,
+    };
+  }
+  return {
+    id: r.id, asset: r.asset, mode: 'precision' as const, status: r.status as 'live' | 'new',
+    startPrice: r.startPrice, totalPool: r.totalPool, predictionCount: r.predictionCount, closesAt: r.closesAt,
+  };
+}
+
 export class InMemoryRoundRepository implements RoundRepository {
   async listActiveRounds() {
-    return getMockRounds();
+    return betStore.getRounds().map(storedRoundToMockPredictionRound);
   }
 
-  async placeBet(): Promise<void> {
-    // In-memory mode keeps the historic route contract: accept the bet without
-    // persisting it. This allows route tests and local demos to run DB-free.
+  async placeBet(roundId: string, _address: string, amount: number, side?: "UP" | "DOWN", predictedPrice?: number): Promise<void> {
+    if (side) {
+      betStore.addUpDownBet(roundId, _address, amount, side);
+    } else if (predictedPrice !== undefined) {
+      betStore.addPrecisionBet(roundId, _address, amount, predictedPrice);
+    }
   }
 }
 
@@ -35,6 +48,7 @@ export class InMemoryStatsRepository implements StatsRepository {
     if (!this.cachedStats) {
       this.cachedStats = {
         ...MOCK_PLATFORM_STATS,
+        totalBets: betStore.getTotalBetsCount(),
         isFallback: true,
         cachedAt: new Date().toISOString(),
       };

--- a/src/services/bet.service.ts
+++ b/src/services/bet.service.ts
@@ -1,3 +1,4 @@
+import { betStore } from "../data/bet-store";
 import logger from "../utils/logger";
 import sorobanService from "./soroban.service";
 import betAuditService from "./bet-audit.service";
@@ -26,6 +27,10 @@ export class BetService {
 
     if (process.env.BET_STUB_MODE === "true") {
       logger.info("UP/DOWN bet stub recorded", { ...input, idempotencyKey });
+      const activeRound = betStore.getActiveRound("updown");
+      if (activeRound) {
+        betStore.addUpDownBet(activeRound.id, input.address, input.amount, input.side);
+      }
       result = { state: "stub" };
     } else {
       logger.info("Placing UP/DOWN bet on-chain", { ...input, idempotencyKey });
@@ -52,6 +57,10 @@ export class BetService {
 
     if (process.env.BET_STUB_MODE === "true") {
       logger.info("Precision bet stub recorded", { ...input, idempotencyKey });
+      const activeRound = betStore.getActiveRound("precision");
+      if (activeRound) {
+        betStore.addPrecisionBet(activeRound.id, input.address, input.amount, input.predictedPrice);
+      }
       result = { state: "stub" };
     } else {
       logger.info("Placing Precision bet on-chain", { ...input, idempotencyKey });


### PR DESCRIPTION
## Summary

Store hackathon stub bets in an in-memory analytics store so `GET /api/rounds` and `GET /api/stats` reflect live pool changes during demos, even without on-chain bet wiring.

---

## Changes

| File | Change |
|------|--------|
| `src/data/bet-store.ts` | **New** — In-memory `BetStore` seeded with 3 rounds (matching `seed.ts`); supports `addUpDownBet` / `addPrecisionBet` that mutate pool totals and increment counters |
| `src/data/mockData.ts` | Export `mockLeaderboard` static array (was already imported by `InMemoryLeaderboardRepository` but never declared) |
| `src/repositories/in-memory.repositories.ts` | `InMemoryRoundRepository` now reads/writes from `BetStore` instead of Prisma-backed `getMockRounds()`; `placeBet()` actually updates pools. `InMemoryStatsRepository` reads live `totalBets` from `BetStore` |
| `src/services/bet.service.ts` | Both `recordUpDownBet` and `recordPrecisionBet` write to `BetStore` when `BET_STUB_MODE=true` |

## How it works

POST /api/bets/up-down      (BET_STUB_MODE=true)
  → bet.service.ts → BetStore.addUpDownBet() → poolUp/poolDown updated
POST /api/rounds/hackathon/up-down/:id/bet   (DATA_STORE=memory)
  → InMemoryRoundRepository.placeBet() → BetStore.addUpDownBet()
GET /api/rounds/             (DATA_STORE=memory)
  → InMemoryRoundRepository.listActiveRounds() → returns mutated pools
GET /api/stats               (DATA_STORE=memory)
  → InMemoryStatsRepository.getPlatformStats() → totalBets from store

## Verification

- `npm run build` compiles cleanly (pre-existing `rateLimiter.middleware.ts` error is unrelated)
- `BetStore` verified: pools update correctly for UP/DOWN/precision bets; `getTotalBetsCount()` returns correct aggregate; `getActiveRound()` finds live rounds by mode


Closes #334