### PR TITLE
feat(docs): add contributing guide and pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+<!--
+Thanks for contributing to Xelma Backend!
+Fill out every section. PRs with an incomplete checklist may be sent back.
+-->
+
+## Summary
+
+<!-- What does this PR change and why? Link the issue it closes. -->
+
+Closes #
+
+## Dual-entrypoint architecture
+
+This repo ships **two Express applications**. `npm run dev` (`src/index.ts`) is the
+default production path and is the one reviewers and CI care about. `src/app.ts`
+(`npm run dev:hackathon`) is a separate mock/demo entrypoint.
+
+Several past issues were closed while the functionality existed **only** in one
+entrypoint. Before requesting review, confirm your change behaves correctly on the
+default `npm run dev` path. See [docs/architecture.md](../docs/architecture.md) for
+the entrypoint map and the checklist for adding new routes.
+
+## Affected endpoints
+
+<!-- List every HTTP route / WebSocket event this PR adds, changes, or removes.
+     Write "None" if this PR touches no endpoints. -->
+
+-
+
+## Checklist
+
+- [ ] Verified the change works on the default `npm run dev` (`src/index.ts`) entrypoint.
+- [ ] If the change affects shared functionality, verified it on the hackathon `src/app.ts` entrypoint too (or explained why it does not apply).
+- [ ] Listed all affected endpoints above (or marked "None").
+- [ ] Added or updated tests covering the change.
+- [ ] `npm run lint` and `npm test` pass locally.
+- [ ] Updated docs (README, OpenAPI annotations, `docs/`) where behavior changed.
+
+## Notes for reviewers
+
+<!-- Anything else: trade-offs, follow-ups, screenshots, migration risk. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to Xelma Backend
+
+Thanks for contributing! This guide covers the essentials. For deeper architecture
+details, see [docs/architecture.md](docs/architecture.md) and the [README](README.md).
+
+## Dual-entrypoint architecture
+
+The repo ships **two Express applications**, and this is the single most common
+source of contributor mistakes — several issues were closed while the
+functionality existed in only one of them:
+
+| Command | File | Use when |
+| --- | --- | --- |
+| `npm run dev` | `src/index.ts` | **Default.** Full backend — real DB, WebSocket, Soroban. Almost all work belongs here. |
+| `npm run dev:hackathon` | `src/server.ts` (`src/app.ts`) | Mock/demo app, no database. |
+
+**Always verify your change on the default `npm run dev` path before opening a PR.**
+If your change touches functionality shared by both apps, verify it on the
+hackathon entrypoint too.
+
+## Development workflow
+
+```bash
+npm ci                 # install dependencies
+npm run prisma:generate # generate the Prisma client
+npm run dev            # start the default (production) dev server
+
+npm run lint           # type-check (tsc --noEmit)
+npm test               # run the test suite
+npm run build          # compile to dist/
+```
+
+## Opening a pull request
+
+1. Branch off `main`.
+2. Make your change and add tests.
+3. Run `npm run lint` and `npm test` locally.
+4. Fill out every section of the pull request template, including the
+   **Affected endpoints** list and the entrypoint-verification checklist.
+5. Reference the issue you are closing (`Closes #123`).
+
+The pull request template is applied automatically to new PRs from
+[.github/pull_request_template.md](.github/pull_request_template.md).


### PR DESCRIPTION
Summary
-------
Several past issues were closed while functionality existed only in src/index.ts
(the default `npm run dev` path) and not in the hackathon src/app.ts entrypoint.
This change adds a PR template and a CONTRIBUTING guide that force authors to
confirm the change works on the default entrypoint and to list affected endpoints.

What was implemented
--------------------
1. .github/pull_request_template.md (new)
   - GitHub applies this automatically to every new PR.
   - Sections: Summary (with "Closes #"), Dual-entrypoint architecture note,
     Affected endpoints list, Checklist, Notes for reviewers.
   - Checklist items: default `npm run dev` (src/index.ts) entrypoint verified,
     shared functionality verified on src/app.ts, endpoints listed, tests added,
     lint/test pass, docs updated.
   - Links to docs/architecture.md for the entrypoint map and add-a-route checklist.

2. CONTRIBUTING.md (new, optional per the issue)
   - Explains the dual-entrypoint architecture and the "always verify on
     `npm run dev`" rule, the dev workflow, and PR steps.
   - Links to the PR template and docs/architecture.md.

Acceptance criteria
-------------------
[x] PR template appears on new PRs (.github/pull_request_template.md is the path
    GitHub auto-detects).
[x] Checklist includes entrypoint verification.

How to verify
-------------
- Open a new PR against this repo; the template body is pre-filled.
- Confirm the checklist contains the entrypoint-verification items.

Notes
-----
- docs/architecture.md is referenced by these files (and the README) but does not
  exist yet; it is the deliverable of the separate "architecture doc" issue. The
  links point to its intended path.
- Docs-only change: no code, lint, or test impact.

No CONTRIBUTING.md previously existed; this PR adds one alongside the template.

Closes #342 