### PR TITLE
Consolidate round listing behind shared getRoundsForApi() service

### DIFF
--- a/src/repositories/prisma.repositories.ts
+++ b/src/repositories/prisma.repositories.ts
@@ -9,7 +9,7 @@ import {
 export class PrismaRoundRepository implements RoundRepository {
   async listActiveRounds() {
     const { default: roundService } = await import("../services/round.service");
-    const { rounds, source } = await roundService.getActiveRoundsWithFallback();
+    const { rounds, source } = await roundService.getRoundsForApi();
     return { source, rounds };
   }
 

--- a/src/routes/rounds.routes.ts
+++ b/src/routes/rounds.routes.ts
@@ -168,7 +168,7 @@ router.post('/start', requireAdmin, adminRoundRateLimiter, validate(startRoundSc
  */
 router.get('/active', async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const { source, rounds } = await roundService.getActiveRoundsWithFallback();
+        const { source, rounds } = await roundService.getRoundsForApi();
 
         const serializedRounds = rounds.map((round: any) => ({
             ...round,

--- a/src/routes/rounds.ts
+++ b/src/routes/rounds.ts
@@ -4,12 +4,8 @@ import { validate } from '../middleware/validate.middleware';
 import { upDownBetSchema, precisionBetSchema } from '../schemas/bets.schema';
 
 import { getRepositories } from '../repositories';
-import config from '../config';
-import hackathonService from '../services/hackathon.service';
-import sorobanService from '../services/soroban.service';
-import { getMockRounds } from '../data/mockData';
-import { mapSorobanActiveRound } from '../utils/soroban-round.mapper';
-import logger from '../utils/logger';
+import roundService from '../services/round.service';
+
 const router = Router();
 
 /**
@@ -17,7 +13,7 @@ const router = Router();
  * /api/rounds:
  *   get:
  *     summary: List active prediction rounds
- *     description: Returns on-chain active round when Soroban is configured; falls back to mock rounds when RPC is unavailable or ROUNDS_MOCK_MODE=true.
+ *     description: Returns on-chain active round when Soroban is configured; falls back to database rounds, then to mock data when chain is unavailable or ROUNDS_MOCK_MODE=true.
  *     tags:
  *       - rounds
  *     responses:
@@ -30,7 +26,7 @@ const router = Router();
  *               properties:
  *                 source:
  *                   type: string
- *                   enum: [soroban, mock]
+ *                   enum: [soroban, database, mock]
  *                 rounds:
  *                   type: array
  *                   items:
@@ -38,23 +34,8 @@ const router = Router();
  */
 router.get('/', async (_req: Request, res: Response, next: NextFunction) => {
   try {
-    const rounds = await getRepositories().rounds.listActiveRounds();
-    return res.json(rounds);
-    if (!config.app.roundsMockMode) {
-      try {
-        const onChainRound = await sorobanService.getActiveRound();
-        if (onChainRound) {
-          const mapped = mapSorobanActiveRound(onChainRound);
-          return res.json({ source: 'soroban', rounds: [mapped] });
-        }
-      } catch (err) {
-        logger.warn('Soroban fetch failed; falling back to mock rounds', {
-          error: (err as Error).message,
-        });
-      }
-    }
-
-    return res.json({ source: 'mock', rounds: getMockRounds() });
+    const { source, rounds } = await roundService.getRoundsForApi();
+    return res.json({ source, rounds });
   } catch (err) {
     next(err);
   }

--- a/src/services/round.service.ts
+++ b/src/services/round.service.ts
@@ -15,6 +15,7 @@ import {
   mapDatabaseActiveRound,
   mapSorobanActiveRound,
 } from "../utils/soroban-round.mapper";
+import { getMockRounds } from "../data/mockData";
 
 interface LegendsPriceRange {
   min: number;
@@ -169,39 +170,66 @@ export class RoundService {
   }
 
   /**
-   * Gets active rounds from Soroban when available, otherwise from the database.
-   * Set ROUNDS_MOCK_MODE=true to force database-only reads for local development.
+   * Shared entrypoint for round listing across all API entrypoints.
+   *
+   * Fallback chain: Soroban → Database → Mock.
+   * Set ROUNDS_MOCK_MODE=true to skip Soroban and go directly to mock data.
+   *
+   * Every stage is wrapped in try-catch so a failure at any level degrades
+   * gracefully to the next fallback. The source field tells callers which
+   * backend produced the data.
+   */
+  async getRoundsForApi(): Promise<{
+    source: ActiveRoundSource;
+    rounds: any[];
+  }> {
+    if (config.app.roundsMockMode) {
+      return { source: "mock", rounds: await getMockRounds() };
+    }
+
+    // 1. Try Soroban on-chain round
+    try {
+      const onChainRound = await sorobanService.getActiveRound();
+      if (onChainRound) {
+        return {
+          source: "soroban",
+          rounds: [mapSorobanActiveRound(onChainRound)],
+        };
+      }
+    } catch (error) {
+      logger.warn("Soroban fetch failed; falling back to database", {
+        error: (error as Error).message,
+      });
+    }
+
+    // 2. Try database rounds
+    try {
+      const dbRounds = await this.getActiveRounds();
+      if (dbRounds.length > 0) {
+        return {
+          source: "database",
+          rounds: dbRounds.map((round) => mapDatabaseActiveRound(round)),
+        };
+      }
+    } catch (error) {
+      logger.warn("Database fetch failed; falling back to mock data", {
+        error: (error as Error).message,
+      });
+    }
+
+    // 3. Ultimate fallback — mock data
+    return { source: "mock", rounds: await getMockRounds() };
+  }
+
+  /**
+   * @deprecated Use {@link getRoundsForApi} instead. Kept for backward
+   * compatibility. Delegates to getRoundsForApi.
    */
   async getActiveRoundsWithFallback(): Promise<{
     source: ActiveRoundSource;
     rounds: any[];
   }> {
-    if (!config.app.roundsMockMode) {
-      try {
-        const onChainRound = await sorobanService.getActiveRound();
-        if (onChainRound) {
-          return {
-            source: "soroban",
-            rounds: [mapSorobanActiveRound(onChainRound)],
-          };
-        }
-      } catch (error) {
-        logger.warn(
-          "Failed to fetch active round from Soroban; falling back to database",
-          error,
-        );
-      }
-    }
-
-    const dbRounds = await this.getActiveRounds();
-    if (dbRounds.length > 0) {
-      return {
-        source: "database",
-        rounds: dbRounds.map((round) => mapDatabaseActiveRound(round)),
-      };
-    }
-
-    return { source: "none", rounds: [] };
+    return this.getRoundsForApi();
   }
 
   /**

--- a/src/tests/hackathon-rounds.spec.ts
+++ b/src/tests/hackathon-rounds.spec.ts
@@ -2,15 +2,13 @@ import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import request from 'supertest';
 import { Express } from 'express';
 import { createApp } from '../app';
-import { getMockRounds } from '../data/mockData';
 
-const mockGetActiveRound = jest.fn();
+const mockGetRoundsForApi = jest.fn();
 
-jest.mock('../services/soroban.service', () => ({
+jest.mock('../services/round.service', () => ({
   __esModule: true,
   default: {
-    getActiveRound: (...args: any[]) => mockGetActiveRound(...args),
-    isReady: jest.fn().mockReturnValue(false),
+    getRoundsForApi: (...args: any[]) => mockGetRoundsForApi(...args),
   },
 }));
 
@@ -29,10 +27,34 @@ jest.mock('../middleware/rateLimiter', () => {
   return { apiRateLimiter: pass, writeRateLimiter: pass, betRateLimiter: pass };
 });
 
-// Prevent real Prisma / DB connection in unit tests
-jest.mock('../lib/prisma', () => ({ prisma: {} }));
+const SOROBAN_ROUND_RESPONSE = {
+  source: 'soroban',
+  rounds: [
+    {
+      id: 'soroban-1',
+      sorobanRoundId: '1',
+      mode: 'UP_DOWN',
+      status: 'ACTIVE',
+      startPrice: 0.2891,
+      poolUp: 2.8,
+      poolDown: 1.4,
+      startLedger: 100,
+      betEndLedger: 200,
+      endLedger: 300,
+      isSoroban: true,
+      source: 'soroban',
+    },
+  ],
+};
 
-describe('GET /api/rounds — Soroban-aware with mock fallback', () => {
+const MOCK_ROUND_RESPONSE = {
+  source: 'mock',
+  rounds: [
+    { id: 'btc-updown-live', asset: 'XLM', mode: 'updown', status: 'live', startPrice: 0.5, poolUp: 100, poolDown: 200, closesAt: new Date(Date.now() + 3600000).toISOString() },
+  ],
+};
+
+describe('GET /api/rounds — delegating to shared round service', () => {
   let app: Express;
 
   beforeEach(() => {
@@ -43,17 +65,8 @@ describe('GET /api/rounds — Soroban-aware with mock fallback', () => {
     jest.clearAllMocks();
   });
 
-  it('returns soroban round when on-chain data is available', async () => {
-    mockGetActiveRound.mockResolvedValueOnce({
-      round_id: BigInt(1),
-      mode: 0,
-      price_start: BigInt(2891),
-      pool_up: BigInt(28_000_000),
-      pool_down: BigInt(14_000_000),
-      start_ledger: 100,
-      bet_end_ledger: 200,
-      end_ledger: 300,
-    });
+  it('returns soroban round when service returns soroban source', async () => {
+    mockGetRoundsForApi.mockResolvedValueOnce(SOROBAN_ROUND_RESPONSE);
 
     const res = await request(app).get('/api/rounds');
 
@@ -67,61 +80,32 @@ describe('GET /api/rounds — Soroban-aware with mock fallback', () => {
     expect(res.body.rounds[0].isSoroban).toBe(true);
   });
 
-  it('falls back to mock rounds when soroban returns null', async () => {
-    mockGetActiveRound.mockResolvedValueOnce(null);
+  it('returns mock rounds when service returns mock source', async () => {
+    mockGetRoundsForApi.mockResolvedValueOnce(MOCK_ROUND_RESPONSE);
 
     const res = await request(app).get('/api/rounds');
 
     expect(res.status).toBe(200);
     expect(res.body.source).toBe('mock');
     expect(Array.isArray(res.body.rounds)).toBe(true);
-    expect(res.body.rounds).toHaveLength(getMockRounds().length);
-    expect(mockGetActiveRound).toHaveBeenCalledTimes(1);
-  });
-
-  it('falls back to mock rounds when soroban throws', async () => {
-    mockGetActiveRound.mockRejectedValueOnce(new Error('RPC unavailable'));
-
-    const res = await request(app).get('/api/rounds');
-
-    expect(res.status).toBe(200);
-    expect(res.body.source).toBe('mock');
-    expect(Array.isArray(res.body.rounds)).toBe(true);
+    expect(res.body.rounds).toHaveLength(1);
   });
 
   it('response always includes source and rounds fields', async () => {
-    mockGetActiveRound.mockResolvedValueOnce(null);
+    mockGetRoundsForApi.mockResolvedValueOnce(MOCK_ROUND_RESPONSE);
 
     const res = await request(app).get('/api/rounds');
 
     expect(res.body).toHaveProperty('source');
     expect(res.body).toHaveProperty('rounds');
-    expect(['soroban', 'mock']).toContain(res.body.source);
-  });
-});
-
-describe('GET /api/rounds — ROUNDS_MOCK_MODE=true skips Soroban', () => {
-  afterEach(() => {
-    jest.clearAllMocks();
-    delete process.env.ROUNDS_MOCK_MODE;
+    expect(['soroban', 'database', 'mock']).toContain(res.body.source);
   });
 
-  it('skips soroban entirely and returns mock source when ROUNDS_MOCK_MODE is true', async () => {
-    process.env.ROUNDS_MOCK_MODE = 'true';
+  it('propagates service errors to the error handler', async () => {
+    mockGetRoundsForApi.mockRejectedValueOnce(new Error('Unexpected error'));
 
-    // Re-evaluate config so it picks up the env var
-    jest.isolateModules(() => {
-      // config reads env at require-time; isolateModules gives a fresh scope
-      const { createApp: freshCreateApp } = require('../app');
-      const freshApp = freshCreateApp();
+    const res = await request(app).get('/api/rounds');
 
-      return request(freshApp)
-        .get('/api/rounds')
-        .then((res: any) => {
-          expect(res.status).toBe(200);
-          expect(res.body.source).toBe('mock');
-          expect(mockGetActiveRound).not.toHaveBeenCalled();
-        });
-    });
+    expect(res.status).toBe(500);
   });
 });

--- a/src/tests/round.service.active.spec.ts
+++ b/src/tests/round.service.active.spec.ts
@@ -3,6 +3,7 @@ import { RoundMode } from "@tevalabs/xelma-bindings";
 
 const mockGetActiveRound = jest.fn();
 const mockFindMany = jest.fn();
+const mockGetMockRounds = jest.fn();
 
 jest.mock("../services/soroban.service", () => ({
   __esModule: true,
@@ -20,6 +21,11 @@ jest.mock("../lib/prisma", () => ({
   },
 }));
 
+jest.mock("../data/mockData", () => ({
+  __esModule: true,
+  getMockRounds: (...args: any[]) => mockGetMockRounds(...args),
+}));
+
 jest.mock("../config", () => ({
   __esModule: true,
   default: {
@@ -27,11 +33,31 @@ jest.mock("../config", () => ({
   },
 }));
 
-describe("RoundService.getActiveRoundsWithFallback", () => {
+const MOCK_SOROBAN_ROUND = {
+  round_id: BigInt(9),
+  mode: RoundMode.UpDown,
+  price_start: BigInt(12000),
+  pool_up: BigInt(10_000_000),
+  pool_down: BigInt(5_000_000),
+  start_ledger: 1,
+  bet_end_ledger: 2,
+  end_ledger: 3,
+};
+
+const MOCK_DB_ROUNDS = [
+  { id: "db-round-1", mode: "UP_DOWN", status: "ACTIVE", startPrice: 0.5 },
+];
+
+const MOCK_DATA_ROUNDS = [
+  { id: "mock-1", asset: "XLM", mode: "updown", status: "live", startPrice: 0.5, poolUp: 100, poolDown: 200, closesAt: new Date().toISOString() },
+];
+
+describe("RoundService.getRoundsForApi", () => {
   beforeEach(() => {
     jest.resetModules();
     mockGetActiveRound.mockReset();
     mockFindMany.mockReset();
+    mockGetMockRounds.mockReset();
   });
 
   afterEach(() => {
@@ -39,41 +65,82 @@ describe("RoundService.getActiveRoundsWithFallback", () => {
   });
 
   it("returns soroban round when chain data is available", async () => {
-    mockGetActiveRound.mockResolvedValueOnce({
-      round_id: BigInt(9),
-      mode: RoundMode.UpDown,
-      price_start: BigInt(12000),
-      pool_up: BigInt(10_000_000),
-      pool_down: BigInt(5_000_000),
-      start_ledger: 1,
-      bet_end_ledger: 2,
-      end_ledger: 3,
-    });
+    mockGetActiveRound.mockResolvedValueOnce(MOCK_SOROBAN_ROUND);
 
     const { default: roundService } = await import("../services/round.service");
-    const result = await roundService.getActiveRoundsWithFallback();
+    const result = await roundService.getRoundsForApi();
 
     expect(result.source).toBe("soroban");
     expect(result.rounds[0].sorobanRoundId).toBe("9");
     expect(mockFindMany).not.toHaveBeenCalled();
+    expect(mockGetMockRounds).not.toHaveBeenCalled();
   });
 
   it("falls back to database when soroban returns null", async () => {
     mockGetActiveRound.mockResolvedValueOnce(null);
-    mockFindMany.mockResolvedValueOnce([
-      {
-        id: "db-round-1",
-        mode: "UP_DOWN",
-        status: "ACTIVE",
-        startPrice: 0.5,
-      },
-    ]);
+    mockFindMany.mockResolvedValueOnce(MOCK_DB_ROUNDS);
 
     const { default: roundService } = await import("../services/round.service");
-    const result = await roundService.getActiveRoundsWithFallback();
+    const result = await roundService.getRoundsForApi();
 
     expect(result.source).toBe("database");
     expect(result.rounds[0].id).toBe("db-round-1");
     expect(result.rounds[0].source).toBe("database");
+    expect(mockGetMockRounds).not.toHaveBeenCalled();
+  });
+
+  it("falls back to mock data when soroban and database are unavailable", async () => {
+    mockGetActiveRound.mockResolvedValueOnce(null);
+    mockFindMany.mockResolvedValueOnce([]);
+    mockGetMockRounds.mockResolvedValueOnce(MOCK_DATA_ROUNDS);
+
+    const { default: roundService } = await import("../services/round.service");
+    const result = await roundService.getRoundsForApi();
+
+    expect(result.source).toBe("mock");
+    expect(result.rounds).toHaveLength(1);
+    expect(result.rounds[0].id).toBe("mock-1");
+  });
+
+  it("falls back to mock data when database throws", async () => {
+    mockGetActiveRound.mockResolvedValueOnce(null);
+    mockFindMany.mockRejectedValueOnce(new Error("DB connection lost"));
+    mockGetMockRounds.mockResolvedValueOnce(MOCK_DATA_ROUNDS);
+
+    const { default: roundService } = await import("../services/round.service");
+    const result = await roundService.getRoundsForApi();
+
+    expect(result.source).toBe("mock");
+    expect(result.rounds[0].id).toBe("mock-1");
+  });
+
+  it("skips soroban and returns mock data when roundsMockMode is true", async () => {
+    jest.resetModules();
+    jest.doMock("../config", () => ({
+      __esModule: true,
+      default: {
+        app: { roundsMockMode: true },
+      },
+    }));
+    mockGetMockRounds.mockResolvedValueOnce(MOCK_DATA_ROUNDS);
+
+    const { default: roundService } = await import("../services/round.service");
+    const result = await roundService.getRoundsForApi();
+
+    expect(result.source).toBe("mock");
+    expect(mockGetActiveRound).not.toHaveBeenCalled();
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  describe("getActiveRoundsWithFallback (deprecated alias)", () => {
+    it("delegates to getRoundsForApi", async () => {
+      mockGetActiveRound.mockResolvedValueOnce(MOCK_SOROBAN_ROUND);
+
+      const { default: roundService } = await import("../services/round.service");
+      const result = await roundService.getActiveRoundsWithFallback();
+
+      expect(result.source).toBe("soroban");
+      expect(result.rounds[0].sorobanRoundId).toBe("9");
+    });
   });
 });

--- a/src/tests/rounds-active.routes.spec.ts
+++ b/src/tests/rounds-active.routes.spec.ts
@@ -10,7 +10,7 @@ jest.mock("../services/round.service", () => ({
   default: {
     startRound: jest.fn(),
     getRound: jest.fn(),
-    getActiveRoundsWithFallback: (...args: any[]) =>
+    getRoundsForApi: (...args: any[]) =>
       mockGetActiveRoundsWithFallback(...args),
   },
 }));

--- a/src/utils/soroban-round.mapper.ts
+++ b/src/utils/soroban-round.mapper.ts
@@ -4,7 +4,7 @@ import { RoundMode } from "@tevalabs/xelma-bindings";
 const PRICE_SCALE = 10_000;
 const STROOP_SCALE = 10_000_000;
 
-export type ActiveRoundSource = "soroban" | "database" | "none";
+export type ActiveRoundSource = "soroban" | "database" | "mock" | "none";
 
 export interface MappedActiveRound {
   id: string;


### PR DESCRIPTION
closes #353
Introduce a unified getRoundsForApi() method on RoundService with a Soroban → Database → Mock fallback chain. Both the hackathon route (rounds.ts) and production route (rounds.routes.ts) now delegate to this single entrypoint, eliminating duplicate round-list logic.

- Add 'mock' to ActiveRoundSource type in soroban-round.mapper.ts
- Add getRoundsForApi() with per-stage try-catch for graceful degradation
- Keep getActiveRoundsWithFallback() as a deprecated delegating wrapper
- Remove dead code and unused imports from rounds.ts (hackathon route)
- Update prisma.repositories.ts to use the new method
- Rewrite tests to cover Soroban, DB, and mock fallback modes