### PR TITLE
docs: document BET_STUB_MODE and add mode selection tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,5 +29,8 @@ ROUNDS_MOCK_MODE=false
 ROUND_SCHEDULER_ENABLED=false
 ROUND_SCHEDULER_MODE=UP_DOWN
 
+# Bet Mode: true = stub mode (records intent without on-chain calls), false = on-chain via Soroban
+BET_STUB_MODE=true
+
 # Contract ID alias used by hackathon docs
 CONTRACT_ID=

--- a/README.md
+++ b/README.md
@@ -254,6 +254,16 @@ See [docs/architecture.md](docs/architecture.md) for the full architecture decis
 > dedicated worker process runs background jobs while one or more
 > stateless processes serve HTTP — and for safer local debugging.
 
+> **Bet mode (`BET_STUB_MODE`)**: Controls whether `/api/bets` endpoints
+> submit transactions on-chain or just record intent locally.
+>
+> | `BET_STUB_MODE` | `sorobanService.placeBet` | `sorobanService.placePrecisionBet` | Use case |
+> |---|---|---|---|
+> | `true` (default) | Skipped | Skipped | Local dev, demos, hackathon — no Soroban keypairs or deployed contract needed |
+> | `false` | Called | Called | Production — bets are submitted to the Soroban smart contract |
+>
+> The active mode is logged at startup: `Bet mode: STUB (no on-chain calls)` or `Bet mode: ON-CHAIN (Soroban)`.
+
 #### **8a. Outbox Service (`outbox.service.ts`)** — Issue #18
 - **Purpose**: Guarantees at-least-once delivery of notification and WebSocket side-effects
 - **How it works**:
@@ -551,6 +561,9 @@ ROUND_SCHEDULER_MODE=UP_DOWN   # or 'LEGENDS'
 # API-only startup mode (skip oracle polling, schedulers, and price ticker)
 API_ONLY=false  # Set to 'true' to run as a stateless HTTP API only
 
+# Bet Mode: true = stub mode (records intent without on-chain calls), false = on-chain via Soroban
+BET_STUB_MODE=true
+
 # Price Oracle Configuration
 ORACLE_POLLING_INTERVAL_MS=10000    # Interval between price updates (ms)
 ORACLE_REQUEST_TIMEOUT_MS=5000     # Network timeout for requests (ms)
@@ -568,6 +581,12 @@ Operators can tune the oracle's behavior via environment variables to balance pr
 | `ORACLE_REQUEST_TIMEOUT_MS` | Network timeout for the API request. | `5000` (5s) |
 | `ORACLE_MAX_RETRIES` | Number of retry attempts on failure. | `3` |
 | `ORACLE_STALENESS_THRESHOLD_MS` | When to consider the local price data stale. | `60000` (60s) |
+
+#### Bet Mode (`BET_STUB_MODE`)
+
+| Variable | Description | Default |
+| :--- | :--- | :--- |
+| `BET_STUB_MODE` | `true` = stub mode (bets recorded locally, no on-chain calls); `false` = bets submitted to Soroban smart contract | `true` |
 
 #### Database pool/timeout tuning
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,6 +121,11 @@ validateEnv();
 logBindingsValidation();
 logger.info(`Active DATA_MODE=${config.app.dataMode}`);
 
+const betStubMode = process.env.BET_STUB_MODE === "true";
+logger.info(`Bet mode: ${betStubMode ? "STUB (no on-chain calls)" : "ON-CHAIN (Soroban)"}`, {
+  BET_STUB_MODE: betStubMode,
+});
+
 /**
  * Create and configure the Express app without starting any background
  * jobs or binding to a network port. Safe to import in tests.

--- a/src/tests/bet.service.spec.ts
+++ b/src/tests/bet.service.spec.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from "@jest/globals";
+import betService from "../services/bet.service";
+
+// ----------------------------------------------------------------
+// Mocks
+// ----------------------------------------------------------------
+
+jest.mock("../services/soroban.service", () => ({
+  __esModule: true,
+  default: {
+    placeBet: jest.fn(),
+    placePrecisionBet: jest.fn(),
+  },
+}));
+
+jest.mock("../utils/logger", () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+jest.mock("../services/bet-audit.service", () => ({
+  __esModule: true,
+  default: {
+    emitBetAccepted: jest.fn(),
+  },
+}));
+
+import sorobanService from "../services/soroban.service";
+import betAuditService from "../services/bet-audit.service";
+
+const VALID_ADDRESS = "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890";
+
+// ================================================================
+// BetService mode selection tests
+// ================================================================
+
+describe("BetService - mode selection", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  // --------------------------------------------------------------
+  // UP/DOWN bets
+  // --------------------------------------------------------------
+
+  describe("recordUpDownBet", () => {
+    it("returns stub state when BET_STUB_MODE=true", async () => {
+      process.env.BET_STUB_MODE = "true";
+
+      const result = await betService.recordUpDownBet({
+        address: VALID_ADDRESS,
+        amount: 10,
+        side: "UP",
+      });
+
+      expect(result).toEqual({ state: "stub" });
+      expect(sorobanService.placeBet).not.toHaveBeenCalled();
+      expect(betAuditService.emitBetAccepted).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: "UP_DOWN", result: "stub" })
+      );
+    });
+
+    it("calls SorobanService when BET_STUB_MODE=false", async () => {
+      process.env.BET_STUB_MODE = "false";
+      (sorobanService.placeBet as jest.Mock).mockResolvedValue({
+        state: "on-chain-success",
+        txHash: "0xabc",
+      });
+
+      const result = await betService.recordUpDownBet({
+        address: VALID_ADDRESS,
+        amount: 10,
+        side: "DOWN",
+      });
+
+      expect(result).toEqual({ state: "on-chain-success", txHash: "0xabc" });
+      expect(sorobanService.placeBet).toHaveBeenCalledWith(VALID_ADDRESS, 10, "DOWN");
+      expect(betAuditService.emitBetAccepted).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: "UP_DOWN", result: "on-chain-success" })
+      );
+    });
+
+    it("treats unset BET_STUB_MODE as on-chain", async () => {
+      delete process.env.BET_STUB_MODE;
+      (sorobanService.placeBet as jest.Mock).mockResolvedValue({
+        state: "on-chain-success",
+        txHash: "0xdef",
+      });
+
+      const result = await betService.recordUpDownBet({
+        address: VALID_ADDRESS,
+        amount: 5,
+        side: "UP",
+      });
+
+      expect(sorobanService.placeBet).toHaveBeenCalled();
+      expect(result.state).toBe("on-chain-success");
+    });
+  });
+
+  // --------------------------------------------------------------
+  // Precision bets
+  // --------------------------------------------------------------
+
+  describe("recordPrecisionBet", () => {
+    it("returns stub state when BET_STUB_MODE=true", async () => {
+      process.env.BET_STUB_MODE = "true";
+
+      const result = await betService.recordPrecisionBet({
+        address: VALID_ADDRESS,
+        amount: 5,
+        predictedPrice: 0.12,
+      });
+
+      expect(result).toEqual({ state: "stub" });
+      expect(sorobanService.placePrecisionBet).not.toHaveBeenCalled();
+      expect(betAuditService.emitBetAccepted).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: "PRECISION", result: "stub" })
+      );
+    });
+
+    it("calls SorobanService when BET_STUB_MODE=false", async () => {
+      process.env.BET_STUB_MODE = "false";
+      (sorobanService.placePrecisionBet as jest.Mock).mockResolvedValue({
+        state: "on-chain-success",
+        txHash: "0x789",
+      });
+
+      const result = await betService.recordPrecisionBet({
+        address: VALID_ADDRESS,
+        amount: 5,
+        predictedPrice: 0.12,
+      });
+
+      expect(result).toEqual({ state: "on-chain-success", txHash: "0x789" });
+      expect(sorobanService.placePrecisionBet).toHaveBeenCalledWith(VALID_ADDRESS, 5, 0.12);
+      expect(betAuditService.emitBetAccepted).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: "PRECISION", result: "on-chain-success" })
+      );
+    });
+
+    it("treats unset BET_STUB_MODE as on-chain", async () => {
+      delete process.env.BET_STUB_MODE;
+      (sorobanService.placePrecisionBet as jest.Mock).mockResolvedValue({
+        state: "on-chain-success",
+        txHash: "0xghi",
+      });
+
+      const result = await betService.recordPrecisionBet({
+        address: VALID_ADDRESS,
+        amount: 10,
+        predictedPrice: 0.15,
+      });
+
+      expect(sorobanService.placePrecisionBet).toHaveBeenCalled();
+      expect(result.state).toBe("on-chain-success");
+    });
+  });
+});


### PR DESCRIPTION
PR #337  Document BET_STUB_MODE and on-chain bet mode behavior matrix

## Summary

Add explicit env flag documentation and runtime logging for stub vs on-chain bet execution paths.

## Why this matters

Bet endpoints and TODOs reference on-chain calls, but runtime mode switching (`BET_STUB_MODE`) is not documented for contributors. A new developer looking at `/api/bets/up-down` has no quick way to know whether bets hit the blockchain or are recorded locally.

## Changes

### `.env.example`
- Added `BET_STUB_MODE=true` with inline comment explaining stub vs on-chain behavior.

### `src/index.ts`
- Logs active bet mode at startup:
  ```
  Bet mode: STUB (no on-chain calls)
  Bet mode: ON-CHAIN (Soroban)
  ```

### `README.md`
- Added `BET_STUB_MODE` to the env var code block example.
- Added a **"Bet Mode (`BET_STUB_MODE`)"** table in the environment variables section.
- Added a behavior matrix blockquote in Core Services explaining `true` vs `false` for each bet endpoint (`UP/DOWN` and `Precision`).

### `src/tests/bet.service.spec.ts` (new)
- 6 unit tests covering mode selection for `recordUpDownBet` and `recordPrecisionBet`:
  - Returns stub state when `BET_STUB_MODE=true`
  - Calls `SorobanService` when `BET_STUB_MODE=false`
  - Treats unset `BET_STUB_MODE` as on-chain (safe default)

## Behavior Matrix

| `BET_STUB_MODE` | `sorobanService.placeBet` | `sorobanService.placePrecisionBet` | Use case |
|---|---|---|---|
| `true` (default) | Skipped | Skipped | Local dev, demos, hackathon — no Soroban keypairs needed |
| `false` | Called | Called | Production — bets submitted to Soroban smart contract |

## Acceptance Criteria

- [x] README matrix merged.
- [x] Startup logs show active bet mode.
- [x] Tests for mode selection added.

## Verification

```bash
npm run lint          # type-check (pre-existing errors only)
npx jest src/tests/bet.service.spec.ts   # 6 mode-selection tests pass
```
Closes #337 