### PR TITLE
Feat/in memory history fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,5 +29,8 @@ ROUNDS_MOCK_MODE=false
 ROUND_SCHEDULER_ENABLED=false
 ROUND_SCHEDULER_MODE=UP_DOWN
 
+# Bet Mode: true = stub mode (records intent without on-chain calls), false = on-chain via Soroban
+BET_STUB_MODE=true
+
 # Contract ID alias used by hackathon docs
 CONTRACT_ID=

--- a/README.md
+++ b/README.md
@@ -254,6 +254,16 @@ See [docs/architecture.md](docs/architecture.md) for the full architecture decis
 > dedicated worker process runs background jobs while one or more
 > stateless processes serve HTTP — and for safer local debugging.
 
+> **Bet mode (`BET_STUB_MODE`)**: Controls whether `/api/bets` endpoints
+> submit transactions on-chain or just record intent locally.
+>
+> | `BET_STUB_MODE` | `sorobanService.placeBet` | `sorobanService.placePrecisionBet` | Use case |
+> |---|---|---|---|
+> | `true` (default) | Skipped | Skipped | Local dev, demos, hackathon — no Soroban keypairs or deployed contract needed |
+> | `false` | Called | Called | Production — bets are submitted to the Soroban smart contract |
+>
+> The active mode is logged at startup: `Bet mode: STUB (no on-chain calls)` or `Bet mode: ON-CHAIN (Soroban)`.
+
 #### **8a. Outbox Service (`outbox.service.ts`)** — Issue #18
 - **Purpose**: Guarantees at-least-once delivery of notification and WebSocket side-effects
 - **How it works**:
@@ -551,6 +561,9 @@ ROUND_SCHEDULER_MODE=UP_DOWN   # or 'LEGENDS'
 # API-only startup mode (skip oracle polling, schedulers, and price ticker)
 API_ONLY=false  # Set to 'true' to run as a stateless HTTP API only
 
+# Bet Mode: true = stub mode (records intent without on-chain calls), false = on-chain via Soroban
+BET_STUB_MODE=true
+
 # Price Oracle Configuration
 ORACLE_POLLING_INTERVAL_MS=10000    # Interval between price updates (ms)
 ORACLE_REQUEST_TIMEOUT_MS=5000     # Network timeout for requests (ms)
@@ -568,6 +581,12 @@ Operators can tune the oracle's behavior via environment variables to balance pr
 | `ORACLE_REQUEST_TIMEOUT_MS` | Network timeout for the API request. | `5000` (5s) |
 | `ORACLE_MAX_RETRIES` | Number of retry attempts on failure. | `3` |
 | `ORACLE_STALENESS_THRESHOLD_MS` | When to consider the local price data stale. | `60000` (60s) |
+
+#### Bet Mode (`BET_STUB_MODE`)
+
+| Variable | Description | Default |
+| :--- | :--- | :--- |
+| `BET_STUB_MODE` | `true` = stub mode (bets recorded locally, no on-chain calls); `false` = bets submitted to Soroban smart contract | `true` |
 
 #### Database pool/timeout tuning
 

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -75,3 +75,120 @@ export const MOCK_PLATFORM_STATS = {
   totalUsers: 0,
   totalBets: 0,
 } as const;
+
+// ---------------------------------------------------------------------------
+// In-memory leaderboard data (used by InMemoryLeaderboardRepository)
+// ---------------------------------------------------------------------------
+
+export const mockLeaderboard: MockLeaderboardUser[] = [
+  { rank: 1,  address: "GABCDEF12345678901234567890123456789012345678901234", totalWins: 142, totalLosses: 58,  winStreak: 12, xp: 14200, rankTitle: "Diamond"   },
+  { rank: 2,  address: "GBCDEF123456789012345678901234567890123456789012345", totalWins: 98,  totalLosses: 72,  winStreak: 8,  xp: 9800,  rankTitle: "Platinum"  },
+  { rank: 3,  address: "GCDEF1234567890123456789012345678901234567890123456", totalWins: 85,  totalLosses: 65,  winStreak: 6,  xp: 8500,  rankTitle: "Gold"     },
+  { rank: 4,  address: "GDEF12345678901234567890123456789012345678901234567", totalWins: 72,  totalLosses: 48,  winStreak: 5,  xp: 7200,  rankTitle: "Gold"     },
+  { rank: 5,  address: "GEF123456789012345678901234567890123456789012345678", totalWins: 61,  totalLosses: 39,  winStreak: 7,  xp: 6100,  rankTitle: "Silver"   },
+  { rank: 6,  address: "GF1234567890123456789012345678901234567890123456789", totalWins: 54,  totalLosses: 46,  winStreak: 4,  xp: 5400,  rankTitle: "Silver"   },
+  { rank: 7,  address: "G12345678901234567890123456789012345678901234567890", totalWins: 42,  totalLosses: 58,  winStreak: 3,  xp: 4200,  rankTitle: "Bronze"   },
+  { rank: 8,  address: "GHIJK123456789012345678901234567890123456789012345", totalWins: 33,  totalLosses: 67,  winStreak: 2,  xp: 3300,  rankTitle: "Bronze"   },
+  { rank: 9,  address: "GIJKL1234567890123456789012345678901234567890123456", totalWins: 21,  totalLosses: 79,  winStreak: 3,  xp: 2100,  rankTitle: "Bronze"   },
+  { rank: 10, address: "GJKLM12345678901234567890123456789012345678901234567", totalWins: 12,  totalLosses: 88,  winStreak: 1,  xp: 1200,  rankTitle: "Rookie"   },
+];
+
+// ---------------------------------------------------------------------------
+// In-memory bet history types
+// ---------------------------------------------------------------------------
+
+export type MockBetHistoryItem = {
+  roundId: string;
+  asset: string;
+  mode: string;
+  amount: string;
+  side: string | null;
+  predictedPrice: unknown;
+  result: "PENDING" | "WIN" | "LOSS";
+  payout: string | null;
+  timestamp: Date;
+  roundStatus: string;
+};
+
+// ---------------------------------------------------------------------------
+// In-memory bet history generator
+// ---------------------------------------------------------------------------
+
+export function getMockBetHistory(address: string): MockBetHistoryItem[] {
+  if (!address) return [];
+
+  const rounds = [
+    { id: "round-001", mode: "UP_DOWN",   status: "RESOLVED" },
+    { id: "round-002", mode: "LEGENDS",   status: "RESOLVED" },
+    { id: "round-003", mode: "UP_DOWN",   status: "RESOLVED" },
+    { id: "round-004", mode: "LEGENDS",   status: "RESOLVED" },
+    { id: "round-005", mode: "UP_DOWN",   status: "ACTIVE"   },
+    { id: "round-006", mode: "UP_DOWN",   status: "RESOLVED" },
+    { id: "round-007", mode: "LEGENDS",   status: "RESOLVED" },
+    { id: "round-008", mode: "UP_DOWN",   status: "RESOLVED" },
+    { id: "round-009", mode: "LEGENDS",   status: "RESOLVED" },
+    { id: "round-010", mode: "UP_DOWN",   status: "RESOLVED" },
+    { id: "round-011", mode: "LEGENDS",   status: "ACTIVE"   },
+    { id: "round-012", mode: "UP_DOWN",   status: "RESOLVED" },
+    { id: "round-013", mode: "LEGENDS",   status: "RESOLVED" },
+    { id: "round-014", mode: "UP_DOWN",   status: "RESOLVED" },
+    { id: "round-015", mode: "LEGENDS",   status: "RESOLVED" },
+    { id: "round-016", mode: "UP_DOWN",   status: "PENDING"  },
+    { id: "round-017", mode: "UP_DOWN",   status: "RESOLVED" },
+    { id: "round-018", mode: "LEGENDS",   status: "RESOLVED" },
+    { id: "round-019", mode: "UP_DOWN",   status: "RESOLVED" },
+    { id: "round-020", mode: "LEGENDS",   status: "RESOLVED" },
+    { id: "round-021", mode: "UP_DOWN",   status: "ACTIVE"   },
+    { id: "round-022", mode: "LEGENDS",   status: "RESOLVED" },
+    { id: "round-023", mode: "UP_DOWN",   status: "RESOLVED" },
+    { id: "round-024", mode: "LEGENDS",   status: "RESOLVED" },
+    { id: "round-025", mode: "UP_DOWN",   status: "RESOLVED" },
+  ];
+
+  const seeds = [
+    { side: "UP",     amount: "50.00000000",  won: true,  payout: "95.00000000",   predictedPrice: null },
+    { side: "DOWN",   amount: "25.00000000",  won: false, payout: null,            predictedPrice: null },
+    { side: "UP",     amount: "100.00000000", won: true,  payout: "185.00000000",  predictedPrice: null },
+    { side: null,     amount: "30.00000000",  won: true,  payout: "120.00000000",  predictedPrice: { min: 0.10, max: 0.12 } as const },
+    { side: null,     amount: "75.00000000",  won: false, payout: null,            predictedPrice: { min: 0.12, max: 0.14 } as const },
+    { side: "DOWN",   amount: "40.00000000",  won: true,  payout: "76.00000000",   predictedPrice: null },
+    { side: null,     amount: "60.00000000",  won: true,  payout: "180.00000000",  predictedPrice: { min: 0.14, max: 0.16 } as const },
+    { side: "UP",     amount: "90.00000000",  won: false, payout: null,            predictedPrice: null },
+    { side: null,     amount: "45.00000000",  won: false, payout: null,            predictedPrice: { min: 0.08, max: 0.10 } as const },
+    { side: "UP",     amount: "120.00000000", won: true,  payout: "228.00000000",  predictedPrice: null },
+    { side: null,     amount: "55.00000000",  won: null,  payout: null,            predictedPrice: { min: 0.16, max: 0.18 } as const },
+    { side: "DOWN",   amount: "35.00000000",  won: false, payout: null,            predictedPrice: null },
+    { side: null,     amount: "80.00000000",  won: true,  payout: "240.00000000",  predictedPrice: { min: 0.10, max: 0.12 } as const },
+    { side: "UP",     amount: "65.00000000",  won: true,  payout: "123.50000000",  predictedPrice: null },
+    { side: null,     amount: "70.00000000",  won: false, payout: null,            predictedPrice: { min: 0.12, max: 0.14 } as const },
+    { side: "UP",     amount: "20.00000000",  won: null,  payout: null,            predictedPrice: null },
+    { side: "DOWN",   amount: "110.00000000", won: false, payout: null,            predictedPrice: null },
+    { side: null,     amount: "95.00000000",  won: true,  payout: "285.00000000",  predictedPrice: { min: 0.14, max: 0.16 } as const },
+    { side: "UP",     amount: "150.00000000", won: true,  payout: "285.00000000",  predictedPrice: null },
+    { side: null,     amount: "40.00000000",  won: false, payout: null,            predictedPrice: { min: 0.08, max: 0.10 } as const },
+    { side: "DOWN",   amount: "85.00000000",  won: null,  payout: null,            predictedPrice: null },
+    { side: null,     amount: "30.00000000",  won: true,  payout: "90.00000000",   predictedPrice: { min: 0.10, max: 0.12 } as const },
+    { side: "UP",     amount: "200.00000000", won: false, payout: null,            predictedPrice: null },
+    { side: null,     amount: "50.00000000",  won: true,  payout: "150.00000000",  predictedPrice: { min: 0.12, max: 0.14 } as const },
+    { side: "DOWN",   amount: "25.00000000",  won: true,  payout: "47.50000000",   predictedPrice: null },
+  ];
+
+  const baseDate = new Date("2026-06-01T12:00:00.000Z");
+
+  return rounds.map((round, i) => {
+    const seed = seeds[i % seeds.length];
+    const timestamp = new Date(baseDate.getTime() - i * 3600000);
+    return {
+      roundId: round.id,
+      asset: "XLM",
+      mode: round.mode,
+      amount: seed.amount,
+      side: seed.side,
+      predictedPrice: seed.predictedPrice,
+      result: seed.won === null ? "PENDING" : seed.won ? "WIN" : "LOSS",
+      payout: seed.payout,
+      timestamp,
+      roundStatus: round.status,
+    };
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,6 +121,11 @@ validateEnv();
 logBindingsValidation();
 logger.info(`Active DATA_MODE=${config.app.dataMode}`);
 
+const betStubMode = process.env.BET_STUB_MODE === "true";
+logger.info(`Bet mode: ${betStubMode ? "STUB (no on-chain calls)" : "ON-CHAIN (Soroban)"}`, {
+  BET_STUB_MODE: betStubMode,
+});
+
 /**
  * Create and configure the Express app without starting any background
  * jobs or binding to a network port. Safe to import in tests.

--- a/src/routes/user.routes.ts
+++ b/src/routes/user.routes.ts
@@ -3,10 +3,12 @@ import { prisma } from "../lib/prisma";
 import { authenticateUser, AuthenticatedRequest } from "../middleware/auth.middleware";
 import { validate } from "../middleware/validate.middleware";
 import { updateProfileSchema } from "../schemas/user.schema";
-import { unifiedPaginationSchema, UnifiedPaginationParams } from "../schemas/pagination.schema";
+import { unifiedPaginationSchema, UnifiedPaginationParams, encodeCursor } from "../schemas/pagination.schema";
 import { NotFoundError } from "../utils/errors";
 import sorobanService from "../services/soroban.service";
 import { toDecimalString } from "../utils/decimal.util";
+import config from "../config";
+import { getMockBetHistory } from "../data/mockData";
 
 const router = Router();
 
@@ -329,6 +331,11 @@ router.get(
       const { address } = req.params;
       const { limit, offset, cursor } = req.query as unknown as UnifiedPaginationParams;
 
+      // ── In-memory fallback (hackathon mode) ────────────────────────────────────
+      if (config.app.dataStore === "memory") {
+        return handleMockHistory(address, limit, offset, cursor, res);
+      }
+
       // Resolve the user record once — shared by both pagination modes.
       const user = await prisma.user.findUnique({
         where: { walletAddress: address },
@@ -444,6 +451,72 @@ function mapPrediction(p: any) {
     timestamp: p.createdAt,
     roundStatus: p.round.status,
   };
+}
+
+/**
+ * In-memory fallback for GET /api/user/:address/history when DATA_STORE=memory.
+ * Generates deterministic stub predictions so the frontend can demo the full
+ * user journey without PostgreSQL.
+ */
+function handleMockHistory(
+  address: string,
+  limit: number,
+  offset: number,
+  cursor: string | undefined,
+  res: Response,
+): void {
+  const all = getMockBetHistory(address);
+
+  if (!all.length) {
+    res.json({
+      success: true,
+      data: [],
+      ...(cursor
+        ? { nextCursor: null }
+        : { pagination: { limit, offset, total: 0, totalPages: 0 } }),
+    });
+    return;
+  }
+
+  // Cursor-based pagination
+  if (cursor) {
+    let cursorDate: Date;
+    try {
+      cursorDate = new Date(Buffer.from(cursor, "base64url").toString("utf8"));
+      if (isNaN(cursorDate.getTime())) throw new Error("invalid date");
+    } catch {
+      res.status(400).json({
+        success: false,
+        error: "Invalid cursor. Use the nextCursor value returned by a previous response.",
+      });
+      return;
+    }
+
+    const filtered = all.filter((item) => item.timestamp < cursorDate);
+    const hasNextPage = filtered.length > limit;
+    const page = hasNextPage ? filtered.slice(0, limit) : filtered;
+    const nextCursor = hasNextPage
+      ? encodeCursor(page[page.length - 1].timestamp)
+      : null;
+
+    res.json({ success: true, data: page, nextCursor });
+    return;
+  }
+
+  // Offset-based pagination
+  const page = all.slice(offset, offset + limit);
+  const total = all.length;
+
+  res.json({
+    success: true,
+    data: page,
+    pagination: {
+      limit,
+      offset,
+      total,
+      totalPages: Math.ceil(total / limit),
+    },
+  });
 }
 
 /**

--- a/src/tests/bet.service.spec.ts
+++ b/src/tests/bet.service.spec.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from "@jest/globals";
+import betService from "../services/bet.service";
+
+// ----------------------------------------------------------------
+// Mocks
+// ----------------------------------------------------------------
+
+jest.mock("../services/soroban.service", () => ({
+  __esModule: true,
+  default: {
+    placeBet: jest.fn(),
+    placePrecisionBet: jest.fn(),
+  },
+}));
+
+jest.mock("../utils/logger", () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+jest.mock("../services/bet-audit.service", () => ({
+  __esModule: true,
+  default: {
+    emitBetAccepted: jest.fn(),
+  },
+}));
+
+import sorobanService from "../services/soroban.service";
+import betAuditService from "../services/bet-audit.service";
+
+const VALID_ADDRESS = "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890";
+
+// ================================================================
+// BetService mode selection tests
+// ================================================================
+
+describe("BetService - mode selection", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  // --------------------------------------------------------------
+  // UP/DOWN bets
+  // --------------------------------------------------------------
+
+  describe("recordUpDownBet", () => {
+    it("returns stub state when BET_STUB_MODE=true", async () => {
+      process.env.BET_STUB_MODE = "true";
+
+      const result = await betService.recordUpDownBet({
+        address: VALID_ADDRESS,
+        amount: 10,
+        side: "UP",
+      });
+
+      expect(result).toEqual({ state: "stub" });
+      expect(sorobanService.placeBet).not.toHaveBeenCalled();
+      expect(betAuditService.emitBetAccepted).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: "UP_DOWN", result: "stub" })
+      );
+    });
+
+    it("calls SorobanService when BET_STUB_MODE=false", async () => {
+      process.env.BET_STUB_MODE = "false";
+      (sorobanService.placeBet as jest.Mock).mockResolvedValue({
+        state: "on-chain-success",
+        txHash: "0xabc",
+      });
+
+      const result = await betService.recordUpDownBet({
+        address: VALID_ADDRESS,
+        amount: 10,
+        side: "DOWN",
+      });
+
+      expect(result).toEqual({ state: "on-chain-success", txHash: "0xabc" });
+      expect(sorobanService.placeBet).toHaveBeenCalledWith(VALID_ADDRESS, 10, "DOWN");
+      expect(betAuditService.emitBetAccepted).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: "UP_DOWN", result: "on-chain-success" })
+      );
+    });
+
+    it("treats unset BET_STUB_MODE as on-chain", async () => {
+      delete process.env.BET_STUB_MODE;
+      (sorobanService.placeBet as jest.Mock).mockResolvedValue({
+        state: "on-chain-success",
+        txHash: "0xdef",
+      });
+
+      const result = await betService.recordUpDownBet({
+        address: VALID_ADDRESS,
+        amount: 5,
+        side: "UP",
+      });
+
+      expect(sorobanService.placeBet).toHaveBeenCalled();
+      expect(result.state).toBe("on-chain-success");
+    });
+  });
+
+  // --------------------------------------------------------------
+  // Precision bets
+  // --------------------------------------------------------------
+
+  describe("recordPrecisionBet", () => {
+    it("returns stub state when BET_STUB_MODE=true", async () => {
+      process.env.BET_STUB_MODE = "true";
+
+      const result = await betService.recordPrecisionBet({
+        address: VALID_ADDRESS,
+        amount: 5,
+        predictedPrice: 0.12,
+      });
+
+      expect(result).toEqual({ state: "stub" });
+      expect(sorobanService.placePrecisionBet).not.toHaveBeenCalled();
+      expect(betAuditService.emitBetAccepted).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: "PRECISION", result: "stub" })
+      );
+    });
+
+    it("calls SorobanService when BET_STUB_MODE=false", async () => {
+      process.env.BET_STUB_MODE = "false";
+      (sorobanService.placePrecisionBet as jest.Mock).mockResolvedValue({
+        state: "on-chain-success",
+        txHash: "0x789",
+      });
+
+      const result = await betService.recordPrecisionBet({
+        address: VALID_ADDRESS,
+        amount: 5,
+        predictedPrice: 0.12,
+      });
+
+      expect(result).toEqual({ state: "on-chain-success", txHash: "0x789" });
+      expect(sorobanService.placePrecisionBet).toHaveBeenCalledWith(VALID_ADDRESS, 5, 0.12);
+      expect(betAuditService.emitBetAccepted).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: "PRECISION", result: "on-chain-success" })
+      );
+    });
+
+    it("treats unset BET_STUB_MODE as on-chain", async () => {
+      delete process.env.BET_STUB_MODE;
+      (sorobanService.placePrecisionBet as jest.Mock).mockResolvedValue({
+        state: "on-chain-success",
+        txHash: "0xghi",
+      });
+
+      const result = await betService.recordPrecisionBet({
+        address: VALID_ADDRESS,
+        amount: 10,
+        predictedPrice: 0.15,
+      });
+
+      expect(sorobanService.placePrecisionBet).toHaveBeenCalled();
+      expect(result.state).toBe("on-chain-success");
+    });
+  });
+});


### PR DESCRIPTION
PR #325  Add in-memory bet history fallback for hackathon mode without PostgreSQL

## Summary

`GET /api/user/:address/history` uses Prisma directly and is unavailable when running in hackathon in-memory mode (`DATA_STORE=memory`). This PR adds an in-memory stub data fallback so the frontend can demo the full user journey without PostgreSQL.

## Changes

### `src/data/mockData.ts`
- **Fix pre-existing bug**: Added `mockLeaderboard` array with 10 stub users. `InMemoryLeaderboardRepository` imported this but it was missing, causing a TypeScript build error (`TS2724`).
- **Added `MockBetHistoryItem` type** — matches the `mapPrediction` output shape used by the history endpoint.
- **Added `getMockBetHistory(address)`** — generates 25 deterministic stub predictions per address with varied modes (`UP_DOWN`/`LEGENDS`), outcomes (`WIN`/`LOSS`/`PENDING`), payouts, and timestamps (newest-first, 1-hour intervals).

### `src/routes/user.routes.ts`
- Added imports for `config`, `getMockBetHistory`, and `encodeCursor`.
- **`GET /:address/history`**: checks `config.app.dataStore === "memory"` at the top of the handler. If in memory mode, delegates to `handleMockHistory()` before any Prisma calls.
- **Added `handleMockHistory()` function** — implements both cursor and offset pagination with the same response contract as the Prisma path:
  - Cursor mode: `{ success, data, nextCursor }`
  - Offset mode: `{ success, data, pagination: { limit, offset, total, totalPages } }`
  - Empty address returns empty response (same as DB path)
  - Invalid cursor returns `400` (same as DB path)

## Testing

- TypeScript compiles clean (`npx tsc --noEmit`). The only error is pre-existing in `rateLimiter.middleware.ts`.
- Set `DATA_STORE=memory` to activate the fallback; `DATA_STORE=postgres` (default) preserves existing DB behavior unchanged.

## Acceptance Criteria

- [x] History endpoint works in hackathon mode (`DATA_STORE=memory`)
- [x] DB mode (`DATA_STORE=postgres`) behavior unchanged
- [x] Both cursor and offset pagination modes supported
- [x] Pagination response contract matches DB mode
- [x] Frontend can demo full user journey without PostgreSQL locally


Closes #325 