### PR TITLE
feat: implement response envelope with success and error handling

### DIFF
--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -6,6 +6,7 @@ import { checkRedisHealth } from '../lib/redis';
 import { withTimeout } from '../utils/timeout-wrapper';
 import logger from '../utils/logger';
 import { asyncHandler } from '../middleware/errorHandler.middleware';
+import { sendSuccess } from '../utils/response';
 
 const router = Router();
 
@@ -133,7 +134,7 @@ router.get(
       overallStatus = 'healthy';
     }
 
-    res.json({
+    sendSuccess(res, {
       status: overallStatus,
       timestamp: new Date().toISOString(),
       uptime: process.uptime(),

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { getPrices } from '../services/priceService';
 import { asyncHandler } from '../middleware/errorHandler.middleware';
+import { sendSuccess } from '../utils/response';
 
 const router = Router();
 
@@ -29,7 +30,7 @@ router.get(
   '/prices',
   asyncHandler(async (_req, res) => {
     const prices = await getPrices();
-    res.json(prices);
+    sendSuccess(res, prices);
   })
 );
 

--- a/src/routes/leaderboard.ts
+++ b/src/routes/leaderboard.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { getRepositories } from '../repositories';
+import { sendSuccess } from '../utils/response';
 
 const router = Router();
 
@@ -23,7 +24,8 @@ const router = Router();
 router.get('/', async (_req: Request, res: Response, next: NextFunction) => {
   try {
     const result = await getRepositories().leaderboard.listLeaderboard(100, 0);
-    return res.json(result);
+    const { pagination, ...data } = result as Record<string, unknown> & { pagination?: Record<string, unknown> };
+    return sendSuccess(res, data, pagination ? { pagination } : undefined);
   } catch (err) {
     next(err);
   }

--- a/src/routes/rounds.ts
+++ b/src/routes/rounds.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response, NextFunction } from 'express';
 import { betRateLimiter } from '../middleware/rateLimiter';
 import { validate } from '../middleware/validate.middleware';
 import { upDownBetSchema, precisionBetSchema } from '../schemas/bets.schema';
+import { sendSuccess } from '../utils/response';
 
 import { getRepositories } from '../repositories';
 import config from '../config';
@@ -39,13 +40,13 @@ const router = Router();
 router.get('/', async (_req: Request, res: Response, next: NextFunction) => {
   try {
     const rounds = await getRepositories().rounds.listActiveRounds();
-    return res.json(rounds);
+    return sendSuccess(res, rounds);
     if (!config.app.roundsMockMode) {
       try {
         const onChainRound = await sorobanService.getActiveRound();
         if (onChainRound) {
           const mapped = mapSorobanActiveRound(onChainRound);
-          return res.json({ source: 'soroban', rounds: [mapped] });
+          return sendSuccess(res, { source: 'soroban', rounds: [mapped] });
         }
       } catch (err) {
         logger.warn('Soroban fetch failed; falling back to mock rounds', {
@@ -54,7 +55,7 @@ router.get('/', async (_req: Request, res: Response, next: NextFunction) => {
       }
     }
 
-    return res.json({ source: 'mock', rounds: getMockRounds() });
+    return sendSuccess(res, { source: 'mock', rounds: getMockRounds() });
   } catch (err) {
     next(err);
   }
@@ -62,7 +63,7 @@ router.get('/', async (_req: Request, res: Response, next: NextFunction) => {
 
 // TODO: Call contract via Xelma TypeScript bindings — bets must go on-chain; this endpoint is logging/analytics only for now
 router.post('/:id/bet', betRateLimiter, (_req, res) => {
-  res.json({ success: true, message: 'Bet recorded (stub)' });
+  sendSuccess(res, { message: 'Bet recorded (stub)' });
 });
 
 // Hackathon mutation endpoints - with Zod validation for consistent error handling
@@ -71,7 +72,7 @@ router.post('/hackathon/up-down/:id/bet', betRateLimiter, validate(upDownBetSche
     const { id } = req.params;
     const { address, amount, side } = req.body;
     await getRepositories().rounds.placeBet(id, address, amount, side);
-    res.json({ success: true, message: 'Bet recorded (stub)' });
+    sendSuccess(res, { message: 'Bet recorded (stub)' });
   } catch (err) {
     next(err);
   }
@@ -82,7 +83,7 @@ router.post('/hackathon/precision/:id/bet', betRateLimiter, validate(precisionBe
     const { id } = req.params;
     const { address, amount, predictedPrice } = req.body;
     await getRepositories().rounds.placeBet(id, address, amount, undefined, predictedPrice);
-    res.json({ success: true, message: 'Precision bet recorded (stub)' });
+    sendSuccess(res, { message: 'Precision bet recorded (stub)' });
   } catch (err) {
     next(err);
   }

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response } from "express";
 import { getRepositories } from "../repositories";
+import { sendSuccess, sendError } from "../utils/response";
 
 const router = Router();
 
@@ -49,12 +50,10 @@ const router = Router();
 router.get("/", async (_req: Request, res: Response) => {
   try {
     const stats = await getRepositories().stats.getPlatformStats();
-    return res.status(200).json({ success: true, data: stats });
+    return sendSuccess(res, stats);
   } catch (err) {
     console.error("[GET /api/stats] Unexpected error:", err);
-    return res
-      .status(500)
-      .json({ success: false, error: "Failed to retrieve platform stats." });
+    return sendError(res, "Failed to retrieve platform stats.", 500);
   }
 });
 

--- a/src/tests/hackathon-rounds.spec.ts
+++ b/src/tests/hackathon-rounds.spec.ts
@@ -58,13 +58,14 @@ describe('GET /api/rounds — Soroban-aware with mock fallback', () => {
     const res = await request(app).get('/api/rounds');
 
     expect(res.status).toBe(200);
-    expect(res.body.source).toBe('soroban');
-    expect(Array.isArray(res.body.rounds)).toBe(true);
-    expect(res.body.rounds).toHaveLength(1);
-    expect(res.body.rounds[0].sorobanRoundId).toBe('1');
-    expect(res.body.rounds[0].mode).toBe('UP_DOWN');
-    expect(res.body.rounds[0].status).toBe('ACTIVE');
-    expect(res.body.rounds[0].isSoroban).toBe(true);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.source).toBe('soroban');
+    expect(Array.isArray(res.body.data.rounds)).toBe(true);
+    expect(res.body.data.rounds).toHaveLength(1);
+    expect(res.body.data.rounds[0].sorobanRoundId).toBe('1');
+    expect(res.body.data.rounds[0].mode).toBe('UP_DOWN');
+    expect(res.body.data.rounds[0].status).toBe('ACTIVE');
+    expect(res.body.data.rounds[0].isSoroban).toBe(true);
   });
 
   it('falls back to mock rounds when soroban returns null', async () => {
@@ -73,9 +74,10 @@ describe('GET /api/rounds — Soroban-aware with mock fallback', () => {
     const res = await request(app).get('/api/rounds');
 
     expect(res.status).toBe(200);
-    expect(res.body.source).toBe('mock');
-    expect(Array.isArray(res.body.rounds)).toBe(true);
-    expect(res.body.rounds).toHaveLength(getMockRounds().length);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.source).toBe('mock');
+    expect(Array.isArray(res.body.data.rounds)).toBe(true);
+    expect(res.body.data.rounds).toHaveLength(getMockRounds().length);
     expect(mockGetActiveRound).toHaveBeenCalledTimes(1);
   });
 
@@ -85,18 +87,22 @@ describe('GET /api/rounds — Soroban-aware with mock fallback', () => {
     const res = await request(app).get('/api/rounds');
 
     expect(res.status).toBe(200);
-    expect(res.body.source).toBe('mock');
-    expect(Array.isArray(res.body.rounds)).toBe(true);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.source).toBe('mock');
+    expect(Array.isArray(res.body.data.rounds)).toBe(true);
   });
 
-  it('response always includes source and rounds fields', async () => {
+  it('response always uses envelope with success, data, source, and rounds', async () => {
     mockGetActiveRound.mockResolvedValueOnce(null);
 
     const res = await request(app).get('/api/rounds');
 
-    expect(res.body).toHaveProperty('source');
-    expect(res.body).toHaveProperty('rounds');
-    expect(['soroban', 'mock']).toContain(res.body.source);
+    expect(res.body).toHaveProperty('success');
+    expect(res.body).toHaveProperty('data');
+    expect(res.body.data).toHaveProperty('source');
+    expect(res.body.data).toHaveProperty('rounds');
+    expect(res.body.success).toBe(true);
+    expect(['soroban', 'mock']).toContain(res.body.data.source);
   });
 });
 
@@ -119,7 +125,8 @@ describe('GET /api/rounds — ROUNDS_MOCK_MODE=true skips Soroban', () => {
         .get('/api/rounds')
         .then((res: any) => {
           expect(res.status).toBe(200);
-          expect(res.body.source).toBe('mock');
+          expect(res.body.success).toBe(true);
+          expect(res.body.data.source).toBe('mock');
           expect(mockGetActiveRound).not.toHaveBeenCalled();
         });
     });

--- a/src/tests/prices.routes.spec.ts
+++ b/src/tests/prices.routes.spec.ts
@@ -27,11 +27,12 @@ describe('GET /api/prices', () => {
     const res = await request(app).get('/api/prices');
 
     expect(res.status).toBe(200);
-    expect(res.body.BTC).toBe(67_420.12);
-    expect(res.body.ETH).toBe(3_241.55);
-    expect(res.body.XLM).toBe(0.2891);
-    expect(res.body.stale).toBe(false);
-    expect(res.body.lastUpdatedAt).toBeTruthy();
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.BTC).toBe(67_420.12);
+    expect(res.body.data.ETH).toBe(3_241.55);
+    expect(res.body.data.XLM).toBe(0.2891);
+    expect(res.body.data.stale).toBe(false);
+    expect(res.body.data.lastUpdatedAt).toBeTruthy();
   });
 
   it('uses cache on subsequent requests within 30 seconds', async () => {

--- a/src/tests/response-envelope.spec.ts
+++ b/src/tests/response-envelope.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeAll } from "@jest/globals";
+import request from "supertest";
+import express from "express";
+import { createApp } from "../app";
+
+describe("Hackathon API Response Envelope", () => {
+  let app: express.Application;
+
+  beforeAll(() => {
+    app = createApp();
+  });
+
+  const expectSuccessEnvelope = (body: any) => {
+    expect(body).toHaveProperty("success");
+    expect(body).toHaveProperty("data");
+    expect(body.success).toBe(true);
+  };
+
+  it("GET /api returns success envelope with health data", async () => {
+    const res = await request(app).get("/api");
+
+    expect(res.status).toBe(200);
+    expectSuccessEnvelope(res.body);
+    expect(res.body.data).toHaveProperty("status");
+    expect(res.body.data).toHaveProperty("services");
+  });
+
+  it("GET /api/stats returns success envelope with stats data", async () => {
+    const res = await request(app).get("/api/stats");
+
+    expect(res.status).toBe(200);
+    expectSuccessEnvelope(res.body);
+    expect(res.body.data).toHaveProperty("totalRounds");
+    expect(res.body.data).toHaveProperty("totalUsers");
+    expect(res.body.data).toHaveProperty("totalBets");
+  });
+
+  it("GET /api/rounds returns success envelope with rounds data", async () => {
+    const res = await request(app).get("/api/rounds");
+
+    expect(res.status).toBe(200);
+    expectSuccessEnvelope(res.body);
+    expect(res.body.data).toHaveProperty("rounds");
+  });
+
+  it("GET /api/leaderboard returns success envelope with leaderboard data", async () => {
+    const res = await request(app).get("/api/leaderboard");
+
+    expect(res.status).toBe(200);
+    expectSuccessEnvelope(res.body);
+    expect(res.body.data).toHaveProperty("leaderboard");
+  });
+
+  it("GET /api/prices returns success envelope with price data", async () => {
+    const res = await request(app).get("/api/prices");
+
+    expect(res.status).toBe(200);
+    expectSuccessEnvelope(res.body);
+    expect(res.body.data).toHaveProperty("BTC");
+    expect(res.body.data).toHaveProperty("ETH");
+    expect(res.body.data).toHaveProperty("XLM");
+  });
+});

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -1,0 +1,25 @@
+import { Response } from 'express';
+
+export function sendSuccess<T>(
+  res: Response,
+  data: T,
+  meta?: Record<string, unknown>,
+  statusCode: number = 200
+): Response {
+  const body: { success: true; data: T; meta?: Record<string, unknown> } = {
+    success: true,
+    data,
+  };
+  if (meta !== undefined) {
+    body.meta = meta;
+  }
+  return res.status(statusCode).json(body);
+}
+
+export function sendError(
+  res: Response,
+  error: string,
+  statusCode: number = 500
+): Response {
+  return res.status(statusCode).json({ success: false, error });
+}


### PR DESCRIPTION
## Summary

Closes #322 

Standardize hackathon API responses to a consistent `{ success, data, meta? }` envelope across all hackathon endpoints, replacing mixed raw arrays/objects.

## Changes

### New utility
- **`src/utils/response.ts`** — `sendSuccess(res, data, meta?, statusCode)` and `sendError(res, error, statusCode)` helpers that produce the standard envelope. Success responses always return `{ success: true, data }` with an optional `meta` key; errors return `{ success: false, error }`.

### Route migrations

| Route | Before | After |
|---|---|---|
| `GET /api` (health) | `{ status, timestamp, uptime, durationMs, services }` | `{ success: true, data: { status, timestamp, uptime, durationMs, services } }` |
| `GET /api/stats` | `{ success: true, data: {...} }` (already wrapped) | Uses helper, no shape change |
| `GET /api/rounds` | `res.json(rounds)` / `{ source, rounds }` | `{ success: true, data: {...} }` |
| `GET /api/leaderboard` | Raw `res.json(result)` with pagination at top level | `{ success: true, data: { leaderboard, totalUsers, ... }, meta: { pagination } }` |
| `GET /api/prices` | Raw `res.json(prices)` | `{ success: true, data: { BTC, ETH, XLM, ... } }` |
| `POST /:id/bet`, `/hackathon/*/bet` | `{ success: true, message }` | `{ success: true, data: { message } }` |

### Tests
- **`src/tests/hackathon-rounds.spec.ts`** — Updated assertions to expect `res.body.data.*` envelope
- **`src/tests/prices.routes.spec.ts`** — Updated assertions to expect `res.body.data.*` envelope
- **`src/tests/response-envelope.spec.ts`** (new) — Validates all 5 hackathon endpoints return the standard envelope

## Breaking changes

Frontend consumers must update response parsers:

- **Health** (`GET /api`): `response.status` → `response.data.status`
- **Rounds** (`GET /api/rounds`): `response.source` → `response.data.source`, `response.rounds` → `response.data.rounds`
- **Leaderboard** (`GET /api/leaderboard`): `response.leaderboard` → `response.data.leaderboard`, `response.pagination` → `response.meta.pagination`
- **Prices** (`GET /api/prices`): `response.BTC` → `response.data.BTC`, `response.ETH` → `response.data.ETH`, etc.
- **Bets** (`POST /:id/bet`): `response.message` → `response.data.message`

Migration pattern for frontend:

```ts
// Before: ad-hoc per endpoint
const data = response.source ?? response.leaderboard ?? response;

// After: one parser for all
const { success, data, meta } = response;
```
