### PR TITLE
feat: add hackathon environment template for quick setup

### DIFF
--- a/.env.hackathon.example
+++ b/.env.hackathon.example
@@ -1,0 +1,90 @@
+# =============================================================================
+# Hackathon / Demo environment template
+# =============================================================================
+# Copy to .env to get started with zero config:
+#
+#   cp .env.hackathon.example .env
+#   npm install
+#   docker compose up -d postgres
+#   npm run dev
+#
+# Only the vars above the separator below are strictly required. Everything
+# after is optional — the server boots without them.
+# =============================================================================
+
+# --- Required ---
+
+# Server listen port (hackathon server defaults to 3001)
+PORT=3001
+
+# PostgreSQL connection string — used even in mock mode for auth/user storage
+DATABASE_URL=postgresql://xelma:xelma@localhost:5432/xelma
+
+# Signs JWT tokens. Generate a strong one for production:
+#   openssl rand -base64 32
+JWT_SECRET=hackathon-dev-jwt-secret-change-me
+
+# Data mode — "mock" uses Drizzle-backed mock data for rounds/price
+DATA_MODE=mock
+
+# --- Optional (safe defaults shown) ---
+
+# Server
+# NODE_ENV=development
+# CLIENT_URL=http://localhost:5173
+# LOG_LEVEL=info
+# API_ONLY=false
+
+# Round / scheduler
+# ROUNDS_MOCK_MODE=true
+# ROUND_SCHEDULER_ENABLED=false
+# ROUND_SCHEDULER_MODE=UP_DOWN
+
+# Oracle / price polling
+# ORACLE_POLLING_INTERVAL_MS=10000
+# ORACLE_REQUEST_TIMEOUT_MS=5000
+# ORACLE_MAX_RETRIES=3
+# ORACLE_STALENESS_THRESHOLD_MS=60000
+
+# CoinGecko price feeds (free tier, no API key required)
+# COINGECKO_API_URL=https://api.coingecko.com/api/v3/simple/price?ids=stellar&vs_currencies=usd
+# COINGECKO_MULTI_PRICE_URL=https://api.coingecko.com/api/v3/simple/price?ids=bitcoin,ethereum,stellar&vs_currencies=usd
+# COINCAP_API_URL=https://api.coincap.io/v2/assets/stellar
+
+# Soroban / Stellar — only needed for on-chain round operations
+# SOROBAN_CONTRACT_ID=
+# SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+# STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+# SOROBAN_NETWORK=testnet
+# SOROBAN_ADMIN_SECRET=
+# SOROBAN_ORACLE_SECRET=
+# CONTRACT_ID=
+
+# Database pool tuning (optional)
+# DB_CONNECTION_LIMIT=10
+# DB_POOL_TIMEOUT_SECONDS=10
+# DB_CONNECT_TIMEOUT_SECONDS=10
+# DB_STATEMENT_TIMEOUT_MS=0
+# DB_PGBOUNCER=false
+
+# Auth / JWT
+# JWT_EXPIRY=7d
+
+# Feature flags
+# ENABLE_MULTIPLAYER_SOCIAL=true
+# ENABLE_SIMULATION=false
+
+# Retention (cleanup of old challenges, messages, audit logs)
+# RETENTION_AUTH_CHALLENGES_TTL_DAYS=7
+# RETENTION_CHAT_MESSAGES_TTL_DAYS=90
+# RETENTION_AUDIT_LOGS_TTL_DAYS=90
+# RETENTION_BATCH_SIZE=1000
+
+# Outbox (guaranteed at-least-once notification/websocket delivery)
+# OUTBOX_POLL_INTERVAL_SECONDS=5
+# OUTBOX_BATCH_SIZE=50
+# OUTBOX_MAX_ATTEMPTS=5
+# OUTBOX_RETENTION_DAYS=7
+
+# Xelma Bindings (if required by your setup)
+# XELMA_API_KEY=

--- a/README.md
+++ b/README.md
@@ -491,6 +491,11 @@ docker compose --profile full up --build
 cp .env.example .env
 ```
 
+For hackathon/demo mode (mock data, minimal config):
+```bash
+cp .env.hackathon.example .env
+```
+
 ### 2. Configure Environment Variables
 
 ## Environment Variables
@@ -2009,6 +2014,12 @@ npx prisma migrate status
 
 This section is designed so a new developer can boot and test the API in minutes.
 
+> **Quickest start** — copy the hackathon env template for zero-config local setup:
+> ```bash
+> cp .env.hackathon.example .env
+> ```
+> Then skip straight to step 4 (migrations).
+
 ### 1. Setup
 
 ```bash
@@ -2020,7 +2031,7 @@ npm install
 docker compose up -d postgres
 
 # 2. Copy and customize your environment variables
-cp .env.example .env
+cp .env.hackathon.example .env
 # Edit .env → set DATABASE_URL and JWT_SECRET
 
 # 3. Generate Prisma client & apply core migrations


### PR DESCRIPTION
## Summary

Add `.env.hackathon.example` for zero-config local demo setup, reducing onboarding friction for new contributors.

## Changes

### `.env.hackathon.example` (new)
Minimal environment template for hackathon/demo mode with safe defaults:
- `PORT=3001`, `DATABASE_URL` (Docker Compose Postgres), `JWT_SECRET` (dev placeholder), `DATA_MODE=mock`
- 20+ optional vars commented out with safe defaults grouped by category (Soroban, scheduler, oracle, DB pool, auth, retention, outbox, feature flags)
- New contributor can `cp .env.hackathon.example .env` and boot immediately

### `README.md` (modified)
- Added hackathon env template alternative in **Environment Setup** → **Copy Environment Template**
- Added "Quickest start" callout at top of **Hackathon Quick-Start** directing to `.env.hackathon.example`
- Changed `cp` command in hackathon setup steps from `.env.example` to `.env.hackathon.example`

Closes #326
