### PR TITLE
feat(prices): integrate CoinGecko for multi-asset price retrieval and add fallback handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -227,6 +227,9 @@ export function createApp(): Express {
       });
     });
 
+    // Multi-asset prices via CoinGecko (BTC, ETH, XLM)
+   app.use('/api', pricesRoutes);
+
     // Price Oracle endpoint (returns price_usd as a precise decimal string)
    app.get('/api/price', (req: Request, res: Response) => {
       const price = priceOracle.getPriceString();

--- a/src/services/priceService.ts
+++ b/src/services/priceService.ts
@@ -97,6 +97,13 @@ export const getPrices = async (): Promise<PriceResponse> => {
       return withStaleFlag(cache.data);
     }
 
-    throw err;
+    logger.warn('No cache available — returning static fallback prices');
+    return {
+      BTC: 60_000,
+      ETH: 3_000,
+      XLM: 0.2891,
+      stale: true,
+      lastUpdatedAt: null,
+    };
   }
 };

--- a/src/tests/priceService.spec.ts
+++ b/src/tests/priceService.spec.ts
@@ -56,9 +56,15 @@ describe('priceService', () => {
     expect(stale.stale).toBe(true);
   });
 
-  it('throws when CoinGecko fails and no cache exists', async () => {
+  it('returns static fallback prices when CoinGecko fails and no cache exists', async () => {
     mockedAxios.get.mockRejectedValueOnce(new Error('network error'));
 
-    await expect(getPrices()).rejects.toThrow('network error');
+    const prices = await getPrices();
+
+    expect(prices.BTC).toBe(60_000);
+    expect(prices.ETH).toBe(3_000);
+    expect(prices.XLM).toBe(0.2891);
+    expect(prices.stale).toBe(true);
+    expect(prices.lastUpdatedAt).toBeNull();
   });
 });

--- a/src/tests/prices.routes.spec.ts
+++ b/src/tests/prices.routes.spec.ts
@@ -46,13 +46,17 @@ describe('GET /api/prices', () => {
     expect(mockedAxios.get).toHaveBeenCalledTimes(1);
   });
 
-  it('returns 500 when CoinGecko fails and no cache exists', async () => {
+  it('returns stale fallback prices when CoinGecko fails and no cache exists', async () => {
     mockedAxios.get.mockRejectedValueOnce(new Error('network error'));
     const app = createApp();
 
     const res = await request(app).get('/api/prices');
 
-    expect(res.status).toBe(500);
-    expect(res.body.code).toBe('INTERNAL_SERVER_ERROR');
+    expect(res.status).toBe(200);
+    expect(res.body.BTC).toBe(60_000);
+    expect(res.body.ETH).toBe(3_000);
+    expect(res.body.XLM).toBe(0.2891);
+    expect(res.body.stale).toBe(true);
+    expect(res.body.lastUpdatedAt).toBeNull();
   });
 });


### PR DESCRIPTION

## Summary

Closes #318 

Completes CoinGecko integration in `priceService` (#318). The live CoinGecko fetching skeleton was already in place but had two issues that prevented it from working properly in the default `npm run dev` path:

1. **No graceful fallback on first startup without network** — when CoinGecko failed and no cache existed, `getPrices()` threw, returning 500/503. This broke hackathon startup without network.
2. **Route was never mounted on the main server** — `pricesRoutes` was imported in `src/index.ts` but never wired to Express, so `GET /api/prices` was only accessible via the test-only `src/app.ts`.

## Changes

### `src/services/priceService.ts`
- Replaced the `throw` in the catch block (when CoinGecko fails and no cache exists) with a **static fallback** returning `{ BTC: 60000, ETH: 3000, XLM: 0.2891, stale: true, lastUpdatedAt: null }`.
- Ensures the endpoint never crashes — even on first startup without network, clients get a response with `stale: true` so they can display a degraded UI.

### `src/index.ts`
- Added `app.use('/api', pricesRoutes)` on line 231 to mount the multi-asset price router.
- `GET /api/prices` is now served by the main server alongside the existing oracle-based `GET /api/price`.

### `src/tests/priceService.spec.ts`
- Renamed _"throws when CoinGecko fails and no cache exists"_ → _"returns static fallback prices when CoinGecko fails and no cache exists"_ with assertions for the fallback values, `stale: true`, and `lastUpdatedAt: null`.

### `src/tests/prices.routes.spec.ts`
- Renamed _"returns 500 when CoinGecko fails and no cache exists"_ → _"returns stale fallback prices when CoinGecko fails and no cache exists"_ expecting `200` with the static fallback body.

## Acceptance criteria

- [x] `GET /api/prices` returns live values in dev
- [x] Cache behavior tested (fresh fetch, 30s cache hit, stale cache fallback, static fallback on no-cache)
- [x] No regression for hackathon startup without network
