### PR TITLE
feat: mount production user, bet, and tournament routes in hackathon app

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,8 @@ See [docs/architecture.md](docs/architecture.md) for the full architecture decis
 - `GET /stats` - [Auth] Get detailed user statistics
 - `PATCH /profile` - [Auth] Update user preferences (nickname, avatar, preferences)
 - `GET /transactions` - [Auth] Get paginated transaction history
+- `GET /:address/stats` - Get on-chain user stats from Soroban
+- `GET /:address/history` - Get paginated bet history for a wallet address
 - `GET /:walletAddress/public-profile` - Get any user's public profile
 
 #### **Round Management (`/api/rounds`)**
@@ -310,6 +312,15 @@ See [docs/architecture.md](docs/architecture.md) for the full architecture decis
 - `POST /submit` - [Auth] Submit a prediction for a round
 - `GET /user/:userId` - Get user's prediction history
 - `GET /round/:roundId` - Get all predictions for a round
+
+#### **Bets (`/api/bets`)**
+- `POST /up-down` - [Auth] Submit an UP/DOWN bet (stub or on-chain)
+- `POST /precision` - [Auth] Submit a precision bet (stub or on-chain)
+
+#### **Tournaments (`/api/tournaments`)**
+- `GET /` - List all tournaments (optional `?status=` filter)
+- `GET /:id` - Get tournament detail by id
+- `POST /:id/join` - [Auth] Join a tournament
 
 #### **Leaderboard (`/api/leaderboard`)**
 - `GET /` - Get global leaderboard (paginated, optional auth for user position)
@@ -2008,6 +2019,8 @@ npx prisma migrate status
 ## Hackathon Quick-Start
 
 This section is designed so a new developer can boot and test the API in minutes.
+
+The hackathon entrypoint now exposes the production-style user, bet, and tournament routes under /api/user, /api/bets, and /api/tournaments so frontend integrations can use a single dev command.
 
 ### 1. Setup
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,7 +7,9 @@ import healthRoutes from './routes/health';
 import statsRoutes from './routes/stats';
 import roundsRoutes from './routes/rounds';
 import leaderboardRoutes from './routes/leaderboard';
-import userRoutes from './routes/user';
+import userRoutes from './routes/user.routes';
+import betsRoutes from './routes/bets.routes';
+import tournamentsRoutes from './routes/tournaments.routes';
 import chatRoutes from './routes/chat.routes';
 import notificationsRoutes from './routes/notifications.routes';
 import { apiRateLimiter, writeRateLimiter } from './middleware/rateLimiter';
@@ -69,6 +71,8 @@ export function createApp(options: CreateAppOptions = {}): Application {
   app.use('/api/rounds', roundsRoutes);
   app.use('/api/leaderboard', leaderboardRoutes);
   app.use('/api/user', userRoutes);
+  app.use('/api/bets', betsRoutes);
+  app.use('/api/tournaments', tournamentsRoutes);
 
   if (config.app.enableMultiplayerSocial) {
     app.use('/api/chat', chatRoutes);

--- a/src/routes/tournaments.routes.ts
+++ b/src/routes/tournaments.routes.ts
@@ -1,8 +1,7 @@
 import { Router, Request, Response, NextFunction } from "express";
 import { validate } from "../middleware/validate.middleware";
 import { authenticateUser, AuthenticatedRequest } from "../middleware/auth.middleware";
-import { offsetPaginationSchema } from "../schemas/pagination.schema";
-import { joinTournamentParamsSchema } from "../schemas/tournament.schema";
+import { joinTournamentParamsSchema, tournamentListQuerySchema } from "../schemas/tournament.schema";
 import tournamentService from "../services/tournament.service";
 
 const router = Router();
@@ -80,13 +79,13 @@ const MOCK_TOURNAMENTS: MockTournament[] = [
  */
 router.get(
   "/",
-  validate(offsetPaginationSchema, "query"),
+  validate(tournamentListQuerySchema, "query"),
   (req: Request, res: Response, _next: NextFunction) => {
-    const { limit, offset } = req.query as unknown as {
+    const { limit, offset, status } = req.query as unknown as {
       limit: number;
       offset: number;
+      status?: string;
     };
-    const status = req.query.status as string | undefined;
 
     let filtered = MOCK_TOURNAMENTS;
     if (status) {

--- a/src/schemas/tournament.schema.ts
+++ b/src/schemas/tournament.schema.ts
@@ -1,7 +1,14 @@
 import { z } from "zod";
+import { offsetPaginationSchema } from "./pagination.schema";
 
 export const joinTournamentParamsSchema = z.object({
   id: z.string().min(1, "Tournament ID is required"),
 });
 
 export type JoinTournamentParams = z.infer<typeof joinTournamentParamsSchema>;
+
+export const tournamentListQuerySchema = offsetPaginationSchema.extend({
+  status: z.string().optional(),
+});
+
+export type TournamentListQuery = z.infer<typeof tournamentListQuerySchema>;

--- a/src/tests/hackathon-new-routes.spec.ts
+++ b/src/tests/hackathon-new-routes.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import request from 'supertest';
+
+jest.mock('../services/stellar.service', () => ({
+  isValidStellarAddress: (address: string) => address && address.startsWith('G') && address.length === 56,
+  verifySignature: jest.fn(),
+}));
+
+jest.mock('../services/soroban.service', () => ({
+  getUserStats: jest.fn(),
+  getPendingWinnings: jest.fn(),
+  getHealth: jest.fn(),
+}));
+
+import { createApp } from '../app';
+
+describe('Hackathon new routes', () => {
+  const app = createApp();
+
+  describe('GET /api/tournaments', () => {
+    it('returns paginated tournament list', async () => {
+      const res = await request(app).get('/api/tournaments?limit=10&offset=0');
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(Array.isArray(res.body.data)).toBe(true);
+      expect(res.body.data.length).toBeGreaterThanOrEqual(1);
+      expect(res.body.pagination).toBeDefined();
+      expect(res.body.pagination.total).toBeGreaterThanOrEqual(1);
+    });
+
+    it('filters by status', async () => {
+      const res = await request(app).get('/api/tournaments?status=ACTIVE');
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.every((t: any) => t.status === 'ACTIVE')).toBe(true);
+    });
+  });
+
+  describe('GET /api/tournaments/:id', () => {
+    it('returns tournament detail for known id', async () => {
+      const res = await request(app).get('/api/tournaments/t-001');
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.id).toBe('t-001');
+      expect(res.body.data.name).toBeDefined();
+    });
+
+    it('returns 404 for unknown id', async () => {
+      const res = await request(app).get('/api/tournaments/nonexistent');
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('GET /api/user/profile', () => {
+    it('requires authentication instead of returning 404', async () => {
+      const res = await request(app).get('/api/user/profile');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('POST /api/bets/up-down', () => {
+    it('returns 401 without auth token', async () => {
+      const res = await request(app)
+        .post('/api/bets/up-down')
+        .send({ address: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF', amount: 10, side: 'UP' });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('POST /api/bets/precision', () => {
+    it('returns 401 without auth token', async () => {
+      const res = await request(app)
+        .post('/api/bets/precision')
+        .send({ address: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF', amount: 5, predictedPrice: 0.12 });
+      expect(res.status).toBe(401);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Mount production-style user, bets, and tournament routes through the hackathon entrypoint (`src/app.ts`) so frontend integrations can use a single dev command.

## Changes

### `src/app.ts`
- Switch `/api/user` from legacy hackathon route (`routes/user.ts`) to production implementation (`routes/user.routes.ts`) exposing full profile, balance, stats, transaction history, and public profile endpoints
- Mount `/api/bets` (`routes/bets.routes.ts`) — `POST /up-down` and `POST /precision` with idempotency support and stub/on-chain modes
- Mount `/api/tournaments` (`routes/tournaments.routes.ts`) — list with status filter, detail by id, and authenticated join

### Route conflict verification
All mounts checked against existing hackathon routes:
- `/api/user/stats` (new) ≠ `/api/stats` (existing platform stats) — different paths
- `/api/bets/up-down` (new) ≠ `/api/rounds/:id/bet` (existing) — different prefixes
- `/api/bets/precision` (new) ≠ `/api/rounds/hackathon/precision/:id/bet` (existing) — different prefixes
- `/api/tournaments/:id` (new) — no existing collision

### `src/schemas/tournament.schema.ts` + `src/routes/tournaments.routes.ts`
**Bug fix:** The `offsetPaginationSchema` from `pagination.schema.ts` uses Zod's default `strip` behavior, which silently drops the `status` query param. Added `tournamentListQuerySchema` extending the pagination schema with an optional `status` string field, so `GET /api/tournaments?status=ACTIVE` actually filters.

### `src/tests/hackathon-new-routes.spec.ts`
Smoke tests (7 cases) verifying each mounted path:
- Tournaments: paginated list, status filter, detail by id, 404 for unknown id
- User profile: returns 401 (not 404) without auth token
- Bets up-down: returns 401 without auth token
- Bets precision: returns 401 without auth token

### `README.md`
- Add `/:address/stats` and `/:address/history` to user endpoints
- Add Bets (`/api/bets`) and Tournaments (`/api/tournaments`) documentation sections
- Note in Hackathon Quick-Start that production-style routes are exposed under a single dev command

## Acceptance criteria
- [x] `npm run dev` serves user stats/history, bets, and tournaments
- [x] No duplicate route collisions
- [x] README endpoint list updated
- [x] Smoke tests pass

Closes #247