### PR TITLE
Emit Socket.IO bet:accepted events when bets succeed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1155,8 +1155,23 @@ socket.on('new_notification', (notification) => {
 socket.on('new_message', (message) => {
   console.log('Chat:', message);
 });
+
+// Listen for accepted bets (stub or on-chain) — join the `round` room first
+socket.on('bet:accepted', (data) => {
+  console.log('Bet accepted:', data);
+  // {
+  //   roundId?: string,
+  //   address: string,
+  //   amount: number,
+  //   side?: 'UP' | 'DOWN',
+  //   mode: 'UP_DOWN' | 'PRECISION',
+  //   state: 'stub' | 'on-chain-success',
+  //   txHash?: string
+  // }
+});
 ```
 
+See also [`src/docs/websocket.md`](src/docs/websocket.md) for the Socket.IO client contract.
 ---
 
 ## Testing

--- a/src/docs/websocket.md
+++ b/src/docs/websocket.md
@@ -15,7 +15,7 @@ Connections are established using the standard Socket.IO client library against 
 ```typescript
 import { io } from "socket.io-client";
 
-const socket = io("[https://api.tevalabs.com](https://api.tevalabs.com)", {
+const socket = io("https://api.tevalabs.com", {
   auth: {
     token: "YOUR_JWT_ACCESS_TOKEN"
   },
@@ -23,3 +23,40 @@ const socket = io("[https://api.tevalabs.com](https://api.tevalabs.com)", {
   reconnectionAttempts: 5,
   reconnectionDelay: 1000
 });
+```
+
+Join the `round` room after connect (via your client's room-join handshake) to receive round and bet broadcasts.
+
+---
+
+## Server → Client events
+
+| Event | Room(s) | When |
+| --- | --- | --- |
+| `round:started` / `round_update` | `round`, `round:{id}` | Round lifecycle |
+| `prediction:placed` | `round` | Legacy prediction placement |
+| `bet:accepted` | `round`, `round:{id}` (when `roundId` known) | Successful stub or on-chain bet |
+| `price:update` / `price_update` | `round`, active `round:{id}` | Oracle price ticks |
+| `round:resolved` | `round` | Round resolution |
+| `chat:message` | `chat` | Chat |
+| `notification:new` | `user:{userId}` | User notification |
+
+### `bet:accepted` (Issue #376)
+
+Emitted **once** after `BetService` successfully records a stub bet or places an on-chain bet. Never emitted when Soroban / validation fails.
+
+```typescript
+socket.on("bet:accepted", (payload: {
+  roundId?: string;
+  address: string;
+  amount: number;
+  side?: "UP" | "DOWN";      // UP_DOWN only
+  mode: "UP_DOWN" | "PRECISION";
+  state: string;             // e.g. "stub" | "on-chain-success"
+  txHash?: string;           // present for on-chain placements
+}) => {
+  // Update live pools / activity feed
+});
+```
+
+Both the hackathon entrypoint (`initWebSocket` in `src/server.ts`) and the full backend (`initializeSocket` in `src/index.ts`) publish through `websocketService`, so clients see the same event regardless of which process is running.

--- a/src/services/bet.service.ts
+++ b/src/services/bet.service.ts
@@ -2,6 +2,7 @@ import { betStore } from "../data/bet-store";
 import logger from "../utils/logger";
 import sorobanService from "./soroban.service";
 import betAuditService from "./bet-audit.service";
+import websocketService from "./websocket.service";
 
 export interface UpDownBetInput {
   address: string;
@@ -24,25 +25,39 @@ export class BetService {
     idempotencyKey?: string
   ): Promise<{ state: string; txHash?: string }> {
     let result: { state: string; txHash?: string };
+    let roundId: string | undefined;
 
     if (process.env.BET_STUB_MODE === "true") {
       logger.info("UP/DOWN bet stub recorded", { ...input, idempotencyKey });
       const activeRound = betStore.getActiveRound("updown");
       if (activeRound) {
+        roundId = activeRound.id;
         betStore.addUpDownBet(activeRound.id, input.address, input.amount, input.side);
       }
       result = { state: "stub" };
     } else {
       logger.info("Placing UP/DOWN bet on-chain", { ...input, idempotencyKey });
       result = await sorobanService.placeBet(input.address, input.amount, input.side);
+      roundId = betStore.getActiveRound("updown")?.id;
     }
 
+    // Only reached on success — Soroban failures throw before this point.
     betAuditService.emitBetAccepted({
       address: input.address,
       amount: input.amount,
       side: input.side,
       mode: "UP_DOWN",
       result: result.state,
+      txHash: result.txHash,
+    });
+
+    websocketService.emitBetAccepted({
+      roundId,
+      address: input.address,
+      amount: input.amount,
+      side: input.side,
+      mode: "UP_DOWN",
+      state: result.state,
       txHash: result.txHash,
     });
 
@@ -54,24 +69,37 @@ export class BetService {
     idempotencyKey?: string
   ): Promise<{ state: string; txHash?: string }> {
     let result: { state: string; txHash?: string };
+    let roundId: string | undefined;
 
     if (process.env.BET_STUB_MODE === "true") {
       logger.info("Precision bet stub recorded", { ...input, idempotencyKey });
       const activeRound = betStore.getActiveRound("precision");
       if (activeRound) {
+        roundId = activeRound.id;
         betStore.addPrecisionBet(activeRound.id, input.address, input.amount, input.predictedPrice);
       }
       result = { state: "stub" };
     } else {
       logger.info("Placing Precision bet on-chain", { ...input, idempotencyKey });
       result = await sorobanService.placePrecisionBet(input.address, input.amount, input.predictedPrice);
+      roundId = betStore.getActiveRound("precision")?.id;
     }
 
+    // Only reached on success — Soroban failures throw before this point.
     betAuditService.emitBetAccepted({
       address: input.address,
       amount: input.amount,
       mode: "PRECISION",
       result: result.state,
+      txHash: result.txHash,
+    });
+
+    websocketService.emitBetAccepted({
+      roundId,
+      address: input.address,
+      amount: input.amount,
+      mode: "PRECISION",
+      state: result.state,
       txHash: result.txHash,
     });
 

--- a/src/services/websocket.service.ts
+++ b/src/services/websocket.service.ts
@@ -12,6 +12,7 @@ import { prisma } from '../lib/prisma';
 export const WebSocketEvents = {
   RoundStarted: 'round:started',
   PredictionPlaced: 'prediction:placed',
+  BetAccepted: 'bet:accepted',
   RoundResolved: 'round:resolved',
   PriceUpdate: 'price:update',
   ChatMessage: 'chat:message',
@@ -23,6 +24,17 @@ export const WebSocketEvents = {
 
 export type WebSocketEventName =
   (typeof WebSocketEvents)[keyof typeof WebSocketEvents];
+
+/** Payload for live bet acceptance broadcasts (Issue #376). */
+export interface BetAcceptedPayload {
+  roundId?: string;
+  address: string;
+  amount: number;
+  side?: 'UP' | 'DOWN';
+  mode: 'UP_DOWN' | 'PRECISION';
+  state: string;
+  txHash?: string;
+}
 
 interface SafeEmitInput {
   room: string;
@@ -158,6 +170,30 @@ export class WebSocketService {
     };
     this.safeEmit({ room: 'round', event: WebSocketEvents.PredictionPlaced, payload });
     logger.info(`Emitted prediction:placed for prediction ${prediction.id}`);
+  }
+
+  /**
+   * Emit when a bet is accepted (stub or on-chain). Broadcasts to the
+   * general `round` room and, when known, to `round:{roundId}`.
+   * Used by both the full server (`initializeSocket` → this service) and
+   * the hackathon entrypoint (`initWebSocket` → same service).
+   */
+  emitBetAccepted(payload: BetAcceptedPayload): void {
+    this.safeEmit({
+      room: 'round',
+      event: WebSocketEvents.BetAccepted,
+      payload,
+    });
+    if (payload.roundId) {
+      this.safeEmit({
+        room: `round:${payload.roundId}`,
+        event: WebSocketEvents.BetAccepted,
+        payload,
+      });
+    }
+    logger.info(
+      `Emitted bet:accepted for address=${payload.address} mode=${payload.mode} state=${payload.state}`,
+    );
   }
 
   /**

--- a/src/tests/bet-accepted-socket.spec.ts
+++ b/src/tests/bet-accepted-socket.spec.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from "@jest/globals";
+
+jest.mock("../services/soroban.service", () => ({
+  __esModule: true,
+  default: {
+    placeBet: jest.fn(),
+    placePrecisionBet: jest.fn(),
+  },
+}));
+
+jest.mock("../services/bet-audit.service", () => ({
+  __esModule: true,
+  default: {
+    emitBetAccepted: jest.fn(),
+  },
+  betAuditService: {
+    emitBetAccepted: jest.fn(),
+  },
+}));
+
+jest.mock("../utils/logger", () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const emitMock = jest.fn();
+const toMock = jest.fn(() => ({ emit: emitMock }));
+
+jest.mock("../lib/prisma", () => ({
+  prisma: {
+    round: { findMany: jest.fn().mockResolvedValue([]) },
+  },
+}));
+
+jest.mock("../services/dead-letter-queue.service", () => ({
+  __esModule: true,
+  default: { record: jest.fn() },
+}));
+
+jest.mock("../metrics/application.metrics", () => ({
+  websocketEmitsTotal: { inc: jest.fn() },
+}));
+
+import betService from "../services/bet.service";
+import sorobanService from "../services/soroban.service";
+import websocketService, {
+  WebSocketEvents,
+} from "../services/websocket.service";
+
+const VALID_ADDRESS = "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890";
+
+describe("bet:accepted websocket emission (#376)", () => {
+  const originalStub = process.env.BET_STUB_MODE;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    emitMock.mockClear();
+    toMock.mockClear();
+    websocketService.initialize({ to: toMock } as any);
+  });
+
+  afterEach(() => {
+    process.env.BET_STUB_MODE = originalStub;
+    (websocketService as any).io = null;
+  });
+
+  it("defines a stable bet:accepted event name", () => {
+    expect(WebSocketEvents.BetAccepted).toBe("bet:accepted");
+  });
+
+  it("emits bet:accepted after a successful stub UP/DOWN bet", async () => {
+    process.env.BET_STUB_MODE = "true";
+
+    await betService.recordUpDownBet({
+      address: VALID_ADDRESS,
+      amount: 25,
+      side: "UP",
+    });
+
+    expect(toMock).toHaveBeenCalledWith("round");
+    expect(emitMock).toHaveBeenCalledWith(
+      "bet:accepted",
+      expect.objectContaining({
+        address: VALID_ADDRESS,
+        amount: 25,
+        side: "UP",
+        mode: "UP_DOWN",
+        state: "stub",
+        roundId: "btc-updown-live",
+      }),
+    );
+    // Also published to the round-specific room when roundId is known
+    expect(toMock).toHaveBeenCalledWith("round:btc-updown-live");
+  });
+
+  it("emits bet:accepted after a successful on-chain PRECISION bet", async () => {
+    process.env.BET_STUB_MODE = "false";
+    (sorobanService.placePrecisionBet as jest.Mock).mockResolvedValue({
+      state: "on-chain-success",
+      txHash: "0xdeadbeef",
+    });
+
+    await betService.recordPrecisionBet({
+      address: VALID_ADDRESS,
+      amount: 10,
+      predictedPrice: 0.3,
+    });
+
+    expect(emitMock).toHaveBeenCalledWith(
+      "bet:accepted",
+      expect.objectContaining({
+        address: VALID_ADDRESS,
+        amount: 10,
+        mode: "PRECISION",
+        state: "on-chain-success",
+        txHash: "0xdeadbeef",
+        roundId: "eth-precision-live",
+      }),
+    );
+  });
+
+  it("does not emit bet:accepted when on-chain placement fails", async () => {
+    process.env.BET_STUB_MODE = "false";
+    (sorobanService.placeBet as jest.Mock).mockRejectedValue(
+      new Error("rpc unavailable"),
+    );
+
+    await expect(
+      betService.recordUpDownBet({
+        address: VALID_ADDRESS,
+        amount: 5,
+        side: "DOWN",
+      }),
+    ).rejects.toThrow("rpc unavailable");
+
+    expect(emitMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/bet-audit.spec.ts
+++ b/src/tests/bet-audit.spec.ts
@@ -14,6 +14,16 @@ jest.mock("../services/soroban.service", () => ({
   },
 }));
 
+jest.mock("../services/websocket.service", () => ({
+  __esModule: true,
+  default: {
+    emitBetAccepted: jest.fn(),
+  },
+  WebSocketEvents: {
+    BetAccepted: "bet:accepted",
+  },
+}));
+
 jest.mock("../utils/logger", () => ({
   info: jest.fn(),
   warn: jest.fn(),


### PR DESCRIPTION
## Summary
- Add stable `bet:accepted` event on `websocketService` (rooms: `round` and `round:{id}`).
- Emit from `BetService` after successful stub and on-chain placements only.
- Document payload in README + `src/docs/websocket.md`.
- Add unit coverage for success/failure paths.

Closes #376

## Test plan
- [x] Smoke: stub UP/DOWN emits `bet:accepted` with `state: stub`
- [x] Smoke: on-chain success includes `txHash`
- [x] Smoke: Soroban failure does not emit
- [x] Socket.IO client e2e: live server + client receives `bet:accepted`
- [ ] CI: `bet-accepted-socket.spec.ts` / `bet-audit.spec.ts`