### PR TITLE
Fix Prisma error class imports in errorHandler middleware

### DIFF
--- a/src/middleware/errorHandler.middleware.ts
+++ b/src/middleware/errorHandler.middleware.ts
@@ -1,5 +1,8 @@
 import { Request, Response, NextFunction } from 'express';
-import { Prisma } from '@prisma/client';
+import {
+  PrismaClientKnownRequestError,
+  PrismaClientValidationError,
+} from '@prisma/client/runtime/library';
 import { AppError, ValidationError, ErrorCode } from '../utils/errors';
 import logger from '../utils/logger';
 
@@ -20,7 +23,7 @@ export interface ErrorResponse {
 /**
  * Maps a Prisma known-request error to an AppError.
  */
-function fromPrismaError(err: Prisma.PrismaClientKnownRequestError): AppError {
+function fromPrismaError(err: PrismaClientKnownRequestError): AppError {
   switch (err.code) {
     case 'P2025':
       // Record not found
@@ -59,7 +62,7 @@ export function errorHandler(
 
   if (err instanceof AppError) {
     appError = err;
-  } else if (err instanceof Prisma.PrismaClientKnownRequestError) {
+  } else if (err instanceof PrismaClientKnownRequestError) {
     appError = fromPrismaError(err);
   } else if (
     err instanceof SyntaxError &&
@@ -68,7 +71,7 @@ export function errorHandler(
     (err as any).type === 'entity.parse.failed'
   ) {
     appError = new ValidationError('Malformed JSON body');
-  } else if (err instanceof Prisma.PrismaClientValidationError) {
+  } else if (err instanceof PrismaClientValidationError) {
     appError = new ValidationError('Invalid database query parameters');
   } else if (err instanceof Error) {
     appError = new AppError(err.message || 'Internal Server Error', 500, ErrorCode.INTERNAL_SERVER_ERROR);

--- a/src/tests/errorHandler.spec.ts
+++ b/src/tests/errorHandler.spec.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect } from "@jest/globals";
+import { describe, it, expect, beforeAll } from "@jest/globals";
 import request from "supertest";
 import express, { Request, Response, NextFunction } from "express";
+import {
+  PrismaClientKnownRequestError,
+  PrismaClientValidationError,
+} from "@prisma/client/runtime/library";
 import {
   AppError,
   ValidationError,
@@ -13,6 +17,17 @@ import {
 } from "../utils/errors";
 import { errorHandler } from "../middleware/errorHandler.middleware";
 import { requestIdMiddleware } from "../middleware/requestId.middleware";
+
+function prismaKnownError(
+  code: string,
+  meta?: Record<string, unknown>,
+): PrismaClientKnownRequestError {
+  return new PrismaClientKnownRequestError(`Prisma ${code}`, {
+    code,
+    clientVersion: "test",
+    meta,
+  });
+}
 
 /** Build a minimal Express app with one route that throws the given error */
 function makeApp(thrower: (req: Request, res: Response, next: NextFunction) => void) {
@@ -193,6 +208,81 @@ describe("errorHandler middleware", () => {
     expect(res.body.stack).toBeUndefined();
 
     process.env.NODE_ENV = originalEnv;
+  });
+});
+
+describe("errorHandler Prisma mapping", () => {
+  it("maps P2025 to 404 NOT_FOUND", async () => {
+    const app = makeApp((_req, _res, next) =>
+      next(prismaKnownError("P2025", { cause: "User not found" })),
+    );
+
+    const res = await request(app).get("/test");
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe("NOT_FOUND");
+    expect(res.body.message).toBe("User not found");
+    expect(res.body.path).toBe("/test");
+  });
+
+  it("maps P2025 without meta.cause to default message", async () => {
+    const app = makeApp((_req, _res, next) => next(prismaKnownError("P2025")));
+
+    const res = await request(app).get("/test");
+    expect(res.status).toBe(404);
+    expect(res.body.message).toBe("Record not found");
+  });
+
+  it("maps P2002 to 409 CONFLICT with target fields", async () => {
+    const app = makeApp((_req, _res, next) =>
+      next(prismaKnownError("P2002", { target: ["email", "wallet"] })),
+    );
+
+    const res = await request(app).get("/test");
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("CONFLICT");
+    expect(res.body.message).toBe("Unique constraint failed on: email, wallet");
+  });
+
+  it("maps P2003 to 400 FOREIGN_KEY_VIOLATION", async () => {
+    const app = makeApp((_req, _res, next) => next(prismaKnownError("P2003")));
+
+    const res = await request(app).get("/test");
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("FOREIGN_KEY_VIOLATION");
+    expect(res.body.message).toBe("Related record not found");
+  });
+
+  it("maps unknown Prisma known-request codes to 500", async () => {
+    const app = makeApp((_req, _res, next) => next(prismaKnownError("P9999")));
+
+    const res = await request(app).get("/test");
+    expect(res.status).toBe(500);
+    expect(res.body.code).toBe("INTERNAL_SERVER_ERROR");
+    expect(res.body.message).toBe("Database error");
+  });
+
+  it("maps PrismaClientValidationError to 400 VALIDATION_ERROR", async () => {
+    const app = makeApp((_req, _res, next) =>
+      next(
+        new PrismaClientValidationError("Invalid args", {
+          clientVersion: "test",
+        }),
+      ),
+    );
+
+    const res = await request(app).get("/test");
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("VALIDATION_ERROR");
+    expect(res.body.message).toBe("Invalid database query parameters");
+  });
+
+  it("recognizes runtime-library Prisma errors via instanceof", () => {
+    const known = prismaKnownError("P2025");
+    const validation = new PrismaClientValidationError("bad", {
+      clientVersion: "test",
+    });
+    expect(known).toBeInstanceOf(PrismaClientKnownRequestError);
+    expect(validation).toBeInstanceOf(PrismaClientValidationError);
   });
 });
 


### PR DESCRIPTION
## Summary
- Import `PrismaClientKnownRequestError` and `PrismaClientValidationError` from `@prisma/client/runtime/library` instead of the unresolved `Prisma.*` namespace members.
- Keeps Prisma → AppError mapping (`P2025`/`P2002`/`P2003`/validation) typed and working with `instanceof`.
- Adds Jest coverage for Prisma error-code mapping in `errorHandler.spec.ts`.

## Test plan
- [x] Local smoke suite: 14/14 middleware mapping checks passed (P2025/P2002/P2003/validation/AppError/generic).
- [x] IDE/tsc diagnostics clean for `errorHandler.middleware.ts`.
- [ ] CI: `errorHandler.spec.ts` (integration project) including new Prisma cases.

## Reviewer notes
- Behavior unchanged; this is a TypeScript/runtime import fix for Prisma error classes.
- Scoped to error handling only — intentionally separate from tournament listing (#378).