### PR TITLE
Add tournament mode filter and shared offset pagination helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ See [docs/architecture.md](docs/architecture.md) for the full architecture decis
 - `POST /precision` - [Auth] Submit a precision bet (stub or on-chain)
 
 #### **Tournaments (`/api/tournaments`)**
-- `GET /` - List all tournaments (optional `?status=` filter)
+- `GET /` - List tournaments. Query: `?mode=UP_DOWN|LEGENDS`, `?status=UPCOMING|ACTIVE|COMPLETED|CANCELLED`, `limit`, `offset` (mode and status may be combined). Response: `{ success, data, pagination: { limit, offset, total } }`
 - `GET /:id` - Get tournament detail by id
 - `POST /:id/join` - [Auth] Join a tournament
 
@@ -2323,6 +2323,8 @@ curl "http://localhost:3001/api/leaderboard?limit=10&offset=0"
 
 ```bash
 curl "http://localhost:3001/api/tournaments?limit=10&offset=0"
+curl "http://localhost:3001/api/tournaments?mode=UP_DOWN"
+curl "http://localhost:3001/api/tournaments?status=ACTIVE&mode=LEGENDS&limit=20&offset=0"
 ```
 
 #### Get Tournament Detail

--- a/src/docs/hackathon-openapi.ts
+++ b/src/docs/hackathon-openapi.ts
@@ -120,6 +120,27 @@ export const hackathonSwaggerSpec = swaggerJSDoc({
             },
           },
         },
+        Tournament: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+            description: { type: 'string' },
+            mode: { type: 'string', enum: ['UP_DOWN', 'LEGENDS'] },
+            status: {
+              type: 'string',
+              enum: ['UPCOMING', 'ACTIVE', 'COMPLETED', 'CANCELLED'],
+            },
+            entryFee: { type: 'string' },
+            prizePool: { type: 'string' },
+            maxParticipants: { type: 'integer' },
+            currentParticipants: { type: 'integer' },
+            startTime: { type: 'string', format: 'date-time' },
+            endTime: { type: 'string', format: 'date-time' },
+            rounds: { type: 'integer' },
+            createdAt: { type: 'string', format: 'date-time' },
+          },
+        },
       },
     },
     tags: [
@@ -128,6 +149,7 @@ export const hackathonSwaggerSpec = swaggerJSDoc({
       { name: 'stats', description: 'Platform statistics' },
       { name: 'rounds', description: 'Mock prediction rounds' },
       { name: 'leaderboard', description: 'Mock leaderboard data' },
+      { name: 'tournaments', description: 'Tournament listings and join' },
     ],
   },
   apis: [
@@ -136,5 +158,6 @@ export const hackathonSwaggerSpec = swaggerJSDoc({
     path.join(process.cwd(), 'src/routes/stats.ts'),
     path.join(process.cwd(), 'src/routes/rounds.ts'),
     path.join(process.cwd(), 'src/routes/leaderboard.ts'),
+    path.join(process.cwd(), 'src/routes/tournaments.routes.ts'),
   ],
 });

--- a/src/routes/tournaments.routes.ts
+++ b/src/routes/tournaments.routes.ts
@@ -1,106 +1,90 @@
 import { Router, Request, Response, NextFunction } from "express";
 import { validate } from "../middleware/validate.middleware";
 import { authenticateUser, AuthenticatedRequest } from "../middleware/auth.middleware";
-import { joinTournamentParamsSchema, tournamentListQuerySchema } from "../schemas/tournament.schema";
+import {
+  joinTournamentParamsSchema,
+  tournamentListQuerySchema,
+  TournamentListQuery,
+} from "../schemas/tournament.schema";
 import tournamentService from "../services/tournament.service";
+import { NotFoundError } from "../utils/errors";
 
 const router = Router();
 
-interface MockTournament {
-  id: string;
-  name: string;
-  description: string;
-  mode: "UP_DOWN" | "LEGENDS";
-  status: "UPCOMING" | "ACTIVE" | "COMPLETED";
-  entryFee: string;
-  prizePool: string;
-  maxParticipants: number;
-  currentParticipants: number;
-  startTime: string;
-  endTime: string;
-  rounds: number;
-  createdAt: string;
-}
-
-const MOCK_TOURNAMENTS: MockTournament[] = [
-  {
-    id: "t-001",
-    name: "XLM Prediction Championship",
-    description:
-      "Compete against the best predictors in a multi-round UP/DOWN tournament.",
-    mode: "UP_DOWN",
-    status: "ACTIVE",
-    entryFee: "50",
-    prizePool: "5000",
-    maxParticipants: 100,
-    currentParticipants: 67,
-    startTime: "2026-06-25T10:00:00Z",
-    endTime: "2026-06-28T10:00:00Z",
-    rounds: 10,
-    createdAt: "2026-06-20T12:00:00Z",
-  },
-  {
-    id: "t-002",
-    name: "Legends Weekly Showdown",
-    description:
-      "Range-based prediction tournament for experienced players. Weekly prizes.",
-    mode: "LEGENDS",
-    status: "UPCOMING",
-    entryFee: "100",
-    prizePool: "10000",
-    maxParticipants: 50,
-    currentParticipants: 12,
-    startTime: "2026-07-01T00:00:00Z",
-    endTime: "2026-07-07T23:59:59Z",
-    rounds: 20,
-    createdAt: "2026-06-22T08:00:00Z",
-  },
-  {
-    id: "t-003",
-    name: "Beginner Friendly Cup",
-    description:
-      "Low entry fee tournament perfect for newcomers. Learn and earn!",
-    mode: "UP_DOWN",
-    status: "COMPLETED",
-    entryFee: "10",
-    prizePool: "500",
-    maxParticipants: 200,
-    currentParticipants: 143,
-    startTime: "2026-06-18T00:00:00Z",
-    endTime: "2026-06-20T23:59:59Z",
-    rounds: 5,
-    createdAt: "2026-06-15T10:00:00Z",
-  },
-];
-
 /**
- * GET /api/tournaments
- * List all tournaments with optional status filter.
+ * @openapi
+ * /api/tournaments:
+ *   get:
+ *     tags: [tournaments]
+ *     summary: List tournaments
+ *     description: Supports optional mode and status filters with offset pagination.
+ *     parameters:
+ *       - in: query
+ *         name: mode
+ *         schema:
+ *           type: string
+ *           enum: [UP_DOWN, LEGENDS]
+ *       - in: query
+ *         name: status
+ *         schema:
+ *           type: string
+ *           enum: [UPCOMING, ACTIVE, COMPLETED, CANCELLED]
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 100
+ *           default: 20
+ *       - in: query
+ *         name: offset
+ *         schema:
+ *           type: integer
+ *           minimum: 0
+ *           default: 0
+ *     responses:
+ *       200:
+ *         description: Paginated tournament list
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required: [success, data, pagination]
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Tournament'
+ *                 pagination:
+ *                   type: object
+ *                   required: [limit, offset, total]
+ *                   properties:
+ *                     limit: { type: integer }
+ *                     offset: { type: integer }
+ *                     total: { type: integer }
+ *       400:
+ *         description: Invalid mode or status
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  */
 router.get(
   "/",
   validate(tournamentListQuerySchema, "query"),
-  (req: Request, res: Response, _next: NextFunction) => {
-    const { limit, offset, status } = req.query as unknown as {
-      limit: number;
-      offset: number;
-      status?: string;
-    };
-
-    let filtered = MOCK_TOURNAMENTS;
-    if (status) {
-      const upper = status.toUpperCase();
-      filtered = filtered.filter((t) => t.status === upper);
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const query = req.query as unknown as TournamentListQuery;
+      const result = await tournamentService.listTournaments(query);
+      return res.json({
+        success: true,
+        ...result,
+      });
+    } catch (error) {
+      return next(error);
     }
-
-    const total = filtered.length;
-    const paginated = filtered.slice(offset, offset + limit);
-
-    return res.json({
-      success: true,
-      data: paginated,
-      pagination: { limit, offset, total },
-    });
   },
 );
 
@@ -110,10 +94,9 @@ router.get(
  */
 router.get("/:id", (req: Request, res: Response, next: NextFunction) => {
   const { id } = req.params;
-  const tournament = MOCK_TOURNAMENTS.find((t) => t.id === id);
+  const tournament = tournamentService.getMockById(id);
 
   if (!tournament) {
-    const { NotFoundError } = require("../utils/errors");
     return next(new NotFoundError("Tournament not found"));
   }
 

--- a/src/schemas/tournament.schema.ts
+++ b/src/schemas/tournament.schema.ts
@@ -7,8 +7,21 @@ export const joinTournamentParamsSchema = z.object({
 
 export type JoinTournamentParams = z.infer<typeof joinTournamentParamsSchema>;
 
+export const tournamentModeSchema = z.enum(["UP_DOWN", "LEGENDS"]);
+export const tournamentStatusSchema = z.enum([
+  "UPCOMING",
+  "ACTIVE",
+  "COMPLETED",
+  "CANCELLED",
+]);
+
+/**
+ * Query params for GET /api/tournaments.
+ * Supports mode and/or status filters with shared offset pagination.
+ */
 export const tournamentListQuerySchema = offsetPaginationSchema.extend({
-  status: z.string().optional(),
+  mode: tournamentModeSchema.optional(),
+  status: tournamentStatusSchema.optional(),
 });
 
 export type TournamentListQuery = z.infer<typeof tournamentListQuerySchema>;

--- a/src/services/tournament.service.ts
+++ b/src/services/tournament.service.ts
@@ -1,8 +1,197 @@
+import { GameMode, Prisma, TournamentStatus } from "@prisma/client";
 import { prisma } from "../lib/prisma";
 import { NotFoundError, ConflictError, ValidationError } from "../utils/errors";
+import { buildOffsetPage } from "../utils/pagination.util";
+import type { TournamentListQuery } from "../schemas/tournament.schema";
+
+export interface TournamentListItem {
+  id: string;
+  name: string;
+  description: string;
+  mode: "UP_DOWN" | "LEGENDS";
+  status: "UPCOMING" | "ACTIVE" | "COMPLETED" | "CANCELLED";
+  entryFee: string;
+  prizePool: string;
+  maxParticipants: number;
+  currentParticipants: number;
+  startTime: string;
+  endTime: string;
+  rounds: number;
+  createdAt: string;
+}
+
+/** Seed data for hackathon / mock listing. */
+export const MOCK_TOURNAMENTS: TournamentListItem[] = [
+  {
+    id: "t-001",
+    name: "XLM Prediction Championship",
+    description:
+      "Compete against the best predictors in a multi-round UP/DOWN tournament.",
+    mode: "UP_DOWN",
+    status: "ACTIVE",
+    entryFee: "50",
+    prizePool: "5000",
+    maxParticipants: 100,
+    currentParticipants: 67,
+    startTime: "2026-06-25T10:00:00Z",
+    endTime: "2026-06-28T10:00:00Z",
+    rounds: 10,
+    createdAt: "2026-06-20T12:00:00Z",
+  },
+  {
+    id: "t-002",
+    name: "Legends Weekly Showdown",
+    description:
+      "Range-based prediction tournament for experienced players. Weekly prizes.",
+    mode: "LEGENDS",
+    status: "UPCOMING",
+    entryFee: "100",
+    prizePool: "10000",
+    maxParticipants: 50,
+    currentParticipants: 12,
+    startTime: "2026-07-01T00:00:00Z",
+    endTime: "2026-07-07T23:59:59Z",
+    rounds: 20,
+    createdAt: "2026-06-22T08:00:00Z",
+  },
+  {
+    id: "t-003",
+    name: "Beginner Friendly Cup",
+    description:
+      "Low entry fee tournament perfect for newcomers. Learn and earn!",
+    mode: "UP_DOWN",
+    status: "COMPLETED",
+    entryFee: "10",
+    prizePool: "500",
+    maxParticipants: 200,
+    currentParticipants: 143,
+    startTime: "2026-06-18T00:00:00Z",
+    endTime: "2026-06-20T23:59:59Z",
+    rounds: 5,
+    createdAt: "2026-06-15T10:00:00Z",
+  },
+];
+
+export type TournamentListSource = "mock" | "prisma";
+
+export function resolveTournamentListSource(
+  override?: TournamentListSource,
+): TournamentListSource {
+  if (override) return override;
+  const raw = process.env.TOURNAMENTS_SOURCE?.toLowerCase();
+  if (raw === "prisma" || raw === "db" || raw === "postgres") return "prisma";
+  return "mock";
+}
+
+/**
+ * Apply mode/status filters to an in-memory tournament list.
+ */
+export function filterTournaments(
+  items: TournamentListItem[],
+  filters: { mode?: string; status?: string },
+): TournamentListItem[] {
+  let filtered = items;
+  if (filters.mode) {
+    filtered = filtered.filter((t) => t.mode === filters.mode);
+  }
+  if (filters.status) {
+    filtered = filtered.filter((t) => t.status === filters.status);
+  }
+  return filtered;
+}
+
+function mapPrismaTournament(row: {
+  id: string;
+  name: string;
+  description: string;
+  mode: GameMode;
+  status: TournamentStatus;
+  entryFee: { toString(): string } | string | number;
+  prizePool: { toString(): string } | string | number;
+  maxParticipants: number;
+  currentParticipants: number;
+  startTime: Date;
+  endTime: Date;
+  rounds: number;
+  createdAt: Date;
+}): TournamentListItem {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    mode: row.mode,
+    status: row.status,
+    entryFee: row.entryFee.toString(),
+    prizePool: row.prizePool.toString(),
+    maxParticipants: row.maxParticipants,
+    currentParticipants: row.currentParticipants,
+    startTime: row.startTime.toISOString(),
+    endTime: row.endTime.toISOString(),
+    rounds: row.rounds,
+    createdAt: row.createdAt.toISOString(),
+  };
+}
 
 export class TournamentService {
-  async joinTournament(userId: string, tournamentId: string): Promise<{ currentParticipants: number }> {
+  /**
+   * List tournaments with optional mode/status filters and offset pagination.
+   * Defaults to mock seed data; set TOURNAMENTS_SOURCE=prisma for DB-backed lists.
+   */
+  async listTournaments(
+    query: TournamentListQuery,
+    source: TournamentListSource = resolveTournamentListSource(),
+  ): Promise<{
+    data: TournamentListItem[];
+    pagination: { limit: number; offset: number; total: number };
+  }> {
+    const { limit, offset, mode, status } = query;
+
+    if (source === "prisma") {
+      return this.listFromPrisma({ limit, offset, mode, status });
+    }
+    return this.listFromMock({ limit, offset, mode, status });
+  }
+
+  listFromMock(query: TournamentListQuery) {
+    const { limit, offset, mode, status } = query;
+    const filtered = filterTournaments(MOCK_TOURNAMENTS, { mode, status });
+    const total = filtered.length;
+    const page = filtered.slice(offset, offset + limit);
+    return buildOffsetPage(page, limit, offset, total);
+  }
+
+  async listFromPrisma(query: TournamentListQuery) {
+    const { limit, offset, mode, status } = query;
+    const where: Prisma.TournamentWhereInput = {};
+    if (mode) where.mode = mode as GameMode;
+    if (status) where.status = status as TournamentStatus;
+
+    const [total, rows] = await Promise.all([
+      prisma.tournament.count({ where }),
+      prisma.tournament.findMany({
+        where,
+        orderBy: { startTime: "desc" },
+        skip: offset,
+        take: limit,
+      }),
+    ]);
+
+    return buildOffsetPage(
+      rows.map(mapPrismaTournament),
+      limit,
+      offset,
+      total,
+    );
+  }
+
+  getMockById(id: string): TournamentListItem | undefined {
+    return MOCK_TOURNAMENTS.find((t) => t.id === id);
+  }
+
+  async joinTournament(
+    userId: string,
+    tournamentId: string,
+  ): Promise<{ currentParticipants: number }> {
     const tournament = await prisma.tournament.findUnique({
       where: { id: tournamentId },
     });

--- a/src/tests/hackathon-new-routes.spec.ts
+++ b/src/tests/hackathon-new-routes.spec.ts
@@ -34,6 +34,12 @@ describe('Hackathon new routes', () => {
       expect(res.body.success).toBe(true);
       expect(res.body.data.every((t: any) => t.status === 'ACTIVE')).toBe(true);
     });
+
+    it('filters by mode', async () => {
+      const res = await request(app).get('/api/tournaments?mode=LEGENDS');
+      expect(res.status).toBe(200);
+      expect(res.body.data.every((t: any) => t.mode === 'LEGENDS')).toBe(true);
+    });
   });
 
   describe('GET /api/tournaments/:id', () => {

--- a/src/tests/pagination.util.spec.ts
+++ b/src/tests/pagination.util.spec.ts
@@ -9,6 +9,7 @@ import {
   encodeCursor,
   decodeCursor,
   buildOffsetMeta,
+  buildOffsetPage,
   buildCursorMeta,
   trimSentinel,
 } from "../utils/pagination.util";
@@ -78,6 +79,22 @@ describe("buildOffsetMeta", () => {
   it("hasNextPage is false when total is 0", () => {
     const meta = buildOffsetMeta(20, 0, 0);
     expect(meta.hasNextPage).toBe(false);
+  });
+});
+
+describe("buildOffsetPage", () => {
+  it("returns data with pagination { limit, offset, total }", () => {
+    const page = buildOffsetPage([{ id: 1 }, { id: 2 }], 10, 0, 2);
+    expect(page).toEqual({
+      data: [{ id: 1 }, { id: 2 }],
+      pagination: { limit: 10, offset: 0, total: 2 },
+    });
+  });
+
+  it("keeps empty data with total 0", () => {
+    const page = buildOffsetPage([], 20, 40, 0);
+    expect(page.data).toEqual([]);
+    expect(page.pagination).toEqual({ limit: 20, offset: 40, total: 0 });
   });
 });
 

--- a/src/tests/tournaments.list.spec.ts
+++ b/src/tests/tournaments.list.spec.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import request from "supertest";
+
+jest.mock("../services/stellar.service", () => ({
+  isValidStellarAddress: (address: string) =>
+    Boolean(address && address.startsWith("G") && address.length === 56),
+  verifySignature: jest.fn(),
+}));
+
+jest.mock("../services/soroban.service", () => ({
+  getUserStats: jest.fn(),
+  getPendingWinnings: jest.fn(),
+  getHealth: jest.fn(),
+}));
+
+const mockCount = jest.fn();
+const mockFindMany = jest.fn();
+
+jest.mock("../lib/prisma", () => ({
+  prisma: {
+    tournament: {
+      count: (...args: unknown[]) => mockCount(...args),
+      findMany: (...args: unknown[]) => mockFindMany(...args),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    tournamentParticipant: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  },
+}));
+
+import { createApp } from "../app";
+import tournamentService, {
+  filterTournaments,
+  MOCK_TOURNAMENTS,
+} from "../services/tournament.service";
+
+describe("Tournament listing (#378)", () => {
+  const app = createApp();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.TOURNAMENTS_SOURCE;
+  });
+
+  describe("filterTournaments helper", () => {
+    it("filters by mode only", () => {
+      const result = filterTournaments(MOCK_TOURNAMENTS, { mode: "UP_DOWN" });
+      expect(result.every((t) => t.mode === "UP_DOWN")).toBe(true);
+      expect(result.length).toBe(2);
+    });
+
+    it("filters by status only", () => {
+      const result = filterTournaments(MOCK_TOURNAMENTS, { status: "ACTIVE" });
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe("t-001");
+    });
+
+    it("filters by mode and status together", () => {
+      const result = filterTournaments(MOCK_TOURNAMENTS, {
+        mode: "UP_DOWN",
+        status: "COMPLETED",
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe("t-003");
+    });
+  });
+
+  describe("GET /api/tournaments", () => {
+    it("returns paginated list with stable pagination shape", async () => {
+      const res = await request(app).get("/api/tournaments?limit=10&offset=0");
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(Array.isArray(res.body.data)).toBe(true);
+      expect(res.body.pagination).toEqual({
+        limit: 10,
+        offset: 0,
+        total: expect.any(Number),
+      });
+      expect(res.body.pagination.total).toBe(MOCK_TOURNAMENTS.length);
+    });
+
+    it("filters by mode=UP_DOWN", async () => {
+      const res = await request(app).get("/api/tournaments?mode=UP_DOWN");
+      expect(res.status).toBe(200);
+      expect(res.body.data.every((t: any) => t.mode === "UP_DOWN")).toBe(true);
+      expect(res.body.pagination.total).toBe(2);
+    });
+
+    it("filters by mode=LEGENDS", async () => {
+      const res = await request(app).get("/api/tournaments?mode=LEGENDS");
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.data[0].mode).toBe("LEGENDS");
+      expect(res.body.pagination.total).toBe(1);
+    });
+
+    it("filters by status=ACTIVE", async () => {
+      const res = await request(app).get("/api/tournaments?status=ACTIVE");
+      expect(res.status).toBe(200);
+      expect(res.body.data.every((t: any) => t.status === "ACTIVE")).toBe(true);
+      expect(res.body.pagination.total).toBe(1);
+    });
+
+    it("supports mode + status together", async () => {
+      const res = await request(app).get(
+        "/api/tournaments?mode=UP_DOWN&status=COMPLETED",
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.data[0]).toMatchObject({
+        id: "t-003",
+        mode: "UP_DOWN",
+        status: "COMPLETED",
+      });
+      expect(res.body.pagination).toEqual({
+        limit: 20,
+        offset: 0,
+        total: 1,
+      });
+    });
+
+    it("returns 400 for invalid mode", async () => {
+      const res = await request(app).get("/api/tournaments?mode=INVALID");
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("returns 400 for invalid status", async () => {
+      const res = await request(app).get("/api/tournaments?status=NOPE");
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("applies limit/offset consistently after filtering", async () => {
+      const res = await request(app).get(
+        "/api/tournaments?mode=UP_DOWN&limit=1&offset=1",
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.pagination).toEqual({
+        limit: 1,
+        offset: 1,
+        total: 2,
+      });
+      // Second UP_DOWN tournament after offset 1
+      expect(res.body.data[0].id).toBe("t-003");
+    });
+  });
+
+  describe("listFromPrisma", () => {
+    it("passes mode and status into Prisma where and paginates", async () => {
+      mockCount.mockResolvedValue(1);
+      mockFindMany.mockResolvedValue([
+        {
+          id: "db-1",
+          name: "DB Cup",
+          description: "from db",
+          mode: "LEGENDS",
+          status: "ACTIVE",
+          entryFee: { toString: () => "5" },
+          prizePool: { toString: () => "50" },
+          maxParticipants: 10,
+          currentParticipants: 2,
+          startTime: new Date("2026-07-01T00:00:00Z"),
+          endTime: new Date("2026-07-02T00:00:00Z"),
+          rounds: 3,
+          createdAt: new Date("2026-06-01T00:00:00Z"),
+        },
+      ]);
+
+      const page = await tournamentService.listTournaments(
+        { limit: 10, offset: 0, mode: "LEGENDS", status: "ACTIVE" },
+        "prisma",
+      );
+
+      expect(mockCount).toHaveBeenCalledWith({
+        where: { mode: "LEGENDS", status: "ACTIVE" },
+      });
+      expect(mockFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { mode: "LEGENDS", status: "ACTIVE" },
+          skip: 0,
+          take: 10,
+        }),
+      );
+      expect(page.pagination).toEqual({ limit: 10, offset: 0, total: 1 });
+      expect(page.data).toHaveLength(1);
+      expect(page.data[0]).toMatchObject({
+        id: "db-1",
+        mode: "LEGENDS",
+        status: "ACTIVE",
+        entryFee: "5",
+        prizePool: "50",
+      });
+    });
+  });
+});

--- a/src/utils/pagination.util.ts
+++ b/src/utils/pagination.util.ts
@@ -76,6 +76,24 @@ export function decodeCursor<T extends Record<string, unknown>>(
 // ---------------------------------------------------------------------------
 
 /**
+ * Build a stable offset-paginated response envelope.
+ *
+ * Shape used by tournament listing and other list endpoints:
+ * `{ data, pagination: { limit, offset, total } }`
+ */
+export function buildOffsetPage<T>(
+  items: T[],
+  limit: number,
+  offset: number,
+  total: number,
+): { data: T[]; pagination: { limit: number; offset: number; total: number } } {
+  return {
+    data: items,
+    pagination: { limit, offset, total },
+  };
+}
+
+/**
  * Build the OffsetMeta object from query params + total count.
  */
 export function buildOffsetMeta(


### PR DESCRIPTION
## Summary
- Add optional `mode` (`UP_DOWN` | `LEGENDS`) and enum `status` filters to `GET /api/tournaments`.
- Introduce reusable `buildOffsetPage()` helper with stable `{ data, pagination: { limit, offset, total } }`.
- Apply filters for both mock and Prisma listing paths; invalid `mode` returns HTTP 400.
- Update OpenAPI + README; add coverage for mode/status/combined filters, invalid mode, and pagination.

Closes #378.

## Test plan
- [ ] `GET /api/tournaments?mode=UP_DOWN` — only UP_DOWN rows
- [ ] `GET /api/tournaments?status=ACTIVE` — only ACTIVE rows
- [ ] `GET /api/tournaments?mode=UP_DOWN&status=COMPLETED` — combined filter
- [ ] `GET /api/tournaments?mode=INVALID` — 400
- [ ] `GET /api/tournaments?limit=1&offset=0` — pagination shape + consistent `total`
- [ ] With `TOURNAMENTS_SOURCE=prisma`, same filters applied in Prisma `where`
- [ ] CI: lint / build / test

## Reviewer notes
- Default source remains **mock** unless `TOURNAMENTS_SOURCE` is `prisma`/`db`/`postgres`.
- `status` is now a Zod enum (stricter than free-form string); unknown status values 400 instead of empty lists.
- Response pagination intentionally omits `hasNextPage` on this envelope to match the issue contract (`limit` / `offset` / `total` only).
- Prisma errorHandler import fix is intentionally **not** included here; see #380.