### PR TITLE
feat: add demo tournament seed script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2171,6 +2171,9 @@ npx ts-node src/db/migrate.ts
 # 5. Seed initial mock rounds and user data to Postgres
 npx ts-node src/db/seed.ts
 
+# Optional: seed joinable demo tournaments for /api/tournaments
+npm run db:seed:tournaments
+
 # 6. Start the server
 npm run dev
 ```
@@ -2324,6 +2327,14 @@ curl "http://localhost:3001/api/leaderboard?limit=10&offset=0"
 ```bash
 curl "http://localhost:3001/api/tournaments?limit=10&offset=0"
 ```
+
+For a fresh local database with joinable demo tournaments, run:
+
+```bash
+npm run db:seed:tournaments
+```
+
+The seed is idempotent and upserts three stable tournament IDs covering `ACTIVE`, `UPCOMING`, and `COMPLETED` statuses across both `UP_DOWN` and `LEGENDS` modes.
 
 #### Get Tournament Detail
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prisma:migrate:deploy": "prisma migrate deploy",
     "db:prepare": "prisma generate && prisma migrate deploy",
     "db:seed:mock": "ts-node scripts/seed-mock-data.ts",
+    "db:seed:tournaments": "ts-node scripts/seed-tournaments.ts",
     "dev:hackathon": "ts-node-dev --respawn --transpile-only src/server.ts",
     "smoke-test": "node scripts/smoke-test.js"
   },

--- a/scripts/seed-tournaments.ts
+++ b/scripts/seed-tournaments.ts
@@ -1,0 +1,73 @@
+import { GameMode, PrismaClient, TournamentStatus } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const hoursFromNow = (hours: number): Date => new Date(Date.now() + hours * 60 * 60 * 1000);
+
+const tournamentSeeds = [
+  {
+    id: 'demo-updown-active',
+    name: 'Demo Up/Down Sprint',
+    description: 'Joinable active demo tournament for the binary UP/DOWN game mode.',
+    mode: GameMode.UP_DOWN,
+    status: TournamentStatus.ACTIVE,
+    entryFee: '10',
+    prizePool: '250',
+    maxParticipants: 64,
+    currentParticipants: 0,
+    startTime: hoursFromNow(-1),
+    endTime: hoursFromNow(23),
+    rounds: 6,
+  },
+  {
+    id: 'demo-legends-upcoming',
+    name: 'Demo Legends Open',
+    description: 'Upcoming demo tournament for range-based LEGENDS predictions.',
+    mode: GameMode.LEGENDS,
+    status: TournamentStatus.UPCOMING,
+    entryFee: '25',
+    prizePool: '1000',
+    maxParticipants: 128,
+    currentParticipants: 0,
+    startTime: hoursFromNow(24),
+    endTime: hoursFromNow(72),
+    rounds: 12,
+  },
+  {
+    id: 'demo-updown-completed',
+    name: 'Demo Completed Classic',
+    description: 'Completed historical tournament fixture for list and detail demos.',
+    mode: GameMode.UP_DOWN,
+    status: TournamentStatus.COMPLETED,
+    entryFee: '5',
+    prizePool: '120',
+    maxParticipants: 32,
+    currentParticipants: 0,
+    startTime: hoursFromNow(-72),
+    endTime: hoursFromNow(-24),
+    rounds: 4,
+  },
+];
+
+async function main() {
+  console.log('Seeding demo tournaments...');
+
+  for (const tournament of tournamentSeeds) {
+    await prisma.tournament.upsert({
+      where: { id: tournament.id },
+      update: tournament,
+      create: tournament,
+    });
+  }
+
+  console.log(`Seeded ${tournamentSeeds.length} demo tournaments.`);
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- add an idempotent Prisma seed script for demo tournaments with stable IDs
- cover ACTIVE, UPCOMING, and COMPLETED statuses across UP_DOWN and LEGENDS modes
- expose 
pm run db:seed:tournaments and document it in the local setup/tournament docs

Closes #372

## Validation
- GitHub compare reports this branch is 1 commit ahead / 0 behind upstream main
- static marker check confirms all three stable tournament IDs, all required statuses, both game modes, and the npm script are present
- checked touched files for trailing whitespace
- did not run local npm/Prisma commands because this environment is avoiding project dependency installation and toolchain execution