### PR TITLE
feat: typed Socket.IO event contracts for compile-time client safety

### DIFF
--- a/src/docs/websocket.md
+++ b/src/docs/websocket.md
@@ -1,25 +1,254 @@
-# 🔌 Socket.IO Client Contract Documentation
+# Socket.IO Client Contract Documentation
 
-This document defines the real-time event contract, lifecycle events, and type structures for the Xelma Backend gateway (`src/socket.ts`). It is designed to allow any contributor or frontend engineer to fully integrate real-time tracking without needing to dig into the source code.
+This document defines the real-time event contract, lifecycle events, and type structures for the Xelma Backend gateway (`src/socket.ts`).
+
+> **Type-safe contracts**: All event names and payloads are defined in
+> [`src/types/socket-events.ts`](../types/socket-events.ts). Server emits and
+> client listeners share these types, giving you compile-time safety.
+> Frontend projects can import `TypedClientSocket` directly from that file.
 
 ---
 
-## 🧭 Connection Lifecycle & Authentication
+## Connection Lifecycle & Authentication
 
 ### 1. Connection Requirements
-Connections are established using the standard Socket.IO client library against the root namespace (`/`). Authentication requires a valid JSON Web Token (JWT) provided in the initial handshake payload.
 
-* **Production Gateway URL:** `https://api.tevalabs.com`
-* **Protocol:** WebSocket / Polling fallback
+Connections use the standard Socket.IO client library against the root namespace (`/`). Authentication requires a valid JWT in the initial handshake.
+
+- **Production Gateway URL:** `https://api.tevalabs.com`
+- **Protocol:** WebSocket / polling fallback
 
 ```typescript
 import { io } from "socket.io-client";
+import type { TypedClientSocket } from "../../src/types/socket-events";
 
-const socket = io("[https://api.tevalabs.com](https://api.tevalabs.com)", {
+const socket: TypedClientSocket = io("https://api.tevalabs.com", {
   auth: {
-    token: "YOUR_JWT_ACCESS_TOKEN"
+    token: "YOUR_JWT_ACCESS_TOKEN",
   },
   autoConnect: true,
   reconnectionAttempts: 5,
-  reconnectionDelay: 1000
+  reconnectionDelay: 1000,
 });
+
+// All events are fully typed — no guessing payload shapes
+socket.on("round:started", (data) => {
+  console.log(data.id); // string
+  console.log(data.startPrice); // typed
+});
+```
+
+### 2. Heartbeat Contract
+
+On connect the server emits `server:hello` with the heartbeat configuration:
+
+```typescript
+interface ServerHelloPayload {
+  socketId: string;
+  pingInterval: number;   // 25_000 ms
+  pingTimeout: number;     // 10_000 ms
+  authenticated: boolean;
+  userId?: string;
+}
+```
+
+Clients that do not receive a server ping within `pingInterval + pingTimeout` ms should reconnect.
+
+### 3. Token Expiry & Reconnect
+
+When the JWT expires the server emits `auth:error` then disconnects the socket:
+
+```typescript
+interface AuthErrorPayload {
+  code: "AUTH_TOKEN_EXPIRED" | "AUTH_TOKEN_INVALID";
+  message: string;
+}
+```
+
+**Client flow:**
+1. Listen for `auth:error` events
+2. On `code === "AUTH_TOKEN_EXPIRED"`: call the HTTP token-refresh endpoint
+3. Reconnect with the new token in `socket.handshake.auth.token`
+4. Re-join rooms (e.g. `join:round`, `join:chat`) after reconnect
+
+### 4. Reconnect Continuity
+
+After a reconnect, the server sends a `session:resume` event that lists previously-joined rooms and saved metadata:
+
+```typescript
+interface ResumePayload {
+  rooms: string[];
+  metadata: Record<string, unknown> | null;
+}
+```
+
+Clients can save per-session state via `session:checkpoint`:
+
+```typescript
+socket.emit("session:checkpoint", { lastViewedRound: "abc-123" });
+```
+
+---
+
+## Client-to-Server Events
+
+| Event | Payload | Ack | Description |
+|-------|---------|-----|-------------|
+| `join:round` | `{ roundId?: string }` | — | Join a round room (omit roundId for general round room) |
+| `leave:round` | `{ roundId?: string }` | — | Leave a round room |
+| `join:chat` | — | — | Join the global chat room (auth required) |
+| `leave:chat` | — | — | Leave the chat room |
+| `chat:send` | `{ content: string }` | `ChatAckPayload` | Send a chat message (auth required, rate-limited) |
+| `join:notifications` | — | — | Join personal notification room (auth required) |
+| `session:checkpoint` | `Record<string, unknown>` | — | Save opaque session metadata for reconnect |
+
+### Chat Send Ack
+
+All `chat:send` messages require an ack callback:
+
+```typescript
+type ChatAckPayload =
+  | { ok: true; message: ChatMessage }
+  | { ok: false; error: string; code: "AUTH_REQUIRED" | "INVALID_CONTENT" | "RATE_LIMITED" | "SEND_FAILED" };
+```
+
+---
+
+## Server-to-Client Events
+
+### Round Events
+
+**`round:started`** — A new prediction round begins:
+
+```typescript
+interface RoundStartedPayload {
+  id: string;
+  mode: string;
+  status: string;
+  startTime: unknown;
+  endTime: unknown;
+  startPrice: unknown;
+  priceRanges: unknown;
+}
+```
+
+**`prediction:placed`** — A user placed a prediction:
+
+```typescript
+interface PredictionPlacedPayload {
+  roundId: string;
+  predictionId: string;
+  amount: unknown;
+  side: unknown;
+  priceRange: unknown;
+}
+```
+
+**`round:resolved`** — A round has been resolved with final price:
+
+```typescript
+interface RoundResolvedPayload {
+  id: string;
+  status: string;
+  startPrice: unknown;
+  endPrice: unknown;
+  resolvedAt: unknown;
+  predictions: number;
+  winners: number;
+}
+```
+
+**`round_update`** — Real-time round state update (pool changes, status changes):
+
+```typescript
+interface RoundUpdatePayload {
+  id: string;
+  mode: string;
+  status: string;
+  startTime: string | null;
+  endTime: string | null;
+  startPrice: number | null;
+  endPrice: number | null;
+  poolUp: number;
+  poolDown: number;
+  priceRanges: unknown;
+  resolvedAt: string | null;
+}
+```
+
+Broadcast to both the general `round` room and the round-specific `round:{id}` room.
+
+### Price Events
+
+**`price:update`** and **`price_update`** (both carry the same shape):
+
+```typescript
+interface PriceUpdatePayload {
+  asset: string;      // e.g. "XLM"
+  price: number | string;
+  timestamp: string;  // ISO 8601
+}
+```
+
+### Chat Events
+
+**`chat:message`** — New chat message:
+
+```typescript
+interface ChatMessage {
+  id: string;
+  userId: string;
+  walletAddress: string;
+  content: string;
+  createdAt: string;
+}
+```
+
+### Notification Events
+
+**`notification:new`** — New notification for the user:
+
+```typescript
+interface NotificationNewPayload {
+  id: string;
+  type: string;
+  title: string;
+  message: string;
+  data: unknown;
+  isRead: boolean;
+  createdAt: string;
+}
+```
+
+**`notification:unread-count`** — Updated unread count:
+
+```typescript
+interface UnreadCountPayload {
+  unreadCount: number;
+  timestamp: string;
+}
+```
+
+---
+
+## Typed Client Socket
+
+Import the typed client socket for compile-time safety in frontend projects:
+
+```typescript
+import { io } from "socket.io-client";
+import type { TypedClientSocket } from "@xelma/backend/types/socket-events";
+
+const socket: TypedClientSocket = io("https://api.tevalabs.com", {
+  auth: { token: "YOUR_JWT" },
+});
+
+socket.on("round:started", (data) => {
+  // data is fully typed as RoundStartedPayload
+  console.log(data.id, data.mode);
+});
+
+socket.emit("join:round", { roundId: "abc-123" });
+```
+
+See the full type definitions in [`src/types/socket-events.ts`](../types/socket-events.ts).

--- a/src/services/websocket.service.ts
+++ b/src/services/websocket.service.ts
@@ -1,9 +1,13 @@
-import { Server as SocketIOServer } from 'socket.io';
 import { DispatchChannel } from '@prisma/client';
 import logger from '../utils/logger';
 import deadLetterQueueService from './dead-letter-queue.service';
 import { websocketEmitsTotal } from '../metrics/application.metrics';
 import { prisma } from '../lib/prisma';
+import type {
+  ServerToClientEvents,
+  TypedServer,
+} from '../types/socket-events';
+import type { ChatMessage } from '../types/chat.types';
 
 /**
  * Centralized event names so DLQ replay can map a stored `eventName` back
@@ -24,16 +28,20 @@ export const WebSocketEvents = {
 export type WebSocketEventName =
   (typeof WebSocketEvents)[keyof typeof WebSocketEvents];
 
-interface SafeEmitInput {
+type EventPayloadMap = {
+  [K in keyof ServerToClientEvents]: Parameters<ServerToClientEvents[K]>[0];
+};
+
+interface SafeEmitInput<E extends WebSocketEventName> {
   room: string;
-  event: WebSocketEventName;
-  payload: any;
+  event: E;
+  payload: EventPayloadMap[E];
   userId?: string | null;
 }
 
 export class WebSocketService {
   private static _singleton = new WebSocketService();
-  private io: SocketIOServer | null = null;
+  private io: TypedServer | null = null;
 
   static get instance(): WebSocketService {
     return WebSocketService._singleton;
@@ -50,7 +58,7 @@ export class WebSocketService {
   /**
    * Initialize the WebSocket service with Socket.IO instance
    */
-  initialize(io: SocketIOServer): void {
+  initialize(io: TypedServer): void {
     this.io = io;
     logger.info("WebSocket service initialized");
   }
@@ -58,7 +66,7 @@ export class WebSocketService {
   /**
    * Get the Socket.IO instance
    */
-  getIO(): SocketIOServer | null {
+  getIO(): TypedServer | null {
     return this.io;
   }
 
@@ -68,11 +76,10 @@ export class WebSocketService {
    * replayed (Issue #193). Never throws — emits are fire-and-forget on the
    * caller's hot path.
    */
-  private safeEmit(input: SafeEmitInput): void {
+  private safeEmit<E extends WebSocketEventName>(input: SafeEmitInput<E>): void {
     if (!this.io) {
       logger.warn(`WebSocket not initialized, cannot emit ${input.event}`);
       websocketEmitsTotal.inc({ event: input.event, outcome: 'unavailable' });
-      // fire-and-forget — DLQ helper swallows its own errors
       void deadLetterQueueService.record({
         channel: DispatchChannel.WEBSOCKET_EMIT,
         eventName: input.event,
@@ -84,7 +91,7 @@ export class WebSocketService {
     }
 
     try {
-      this.io.to(input.room).emit(input.event, input.payload);
+      (this.io.to(input.room).emit as any)(input.event, input.payload);
       websocketEmitsTotal.inc({ event: input.event, outcome: 'success' });
     } catch (err) {
       logger.error(`Failed to emit ${input.event}`, { error: err });
@@ -119,12 +126,9 @@ export class WebSocketService {
     if (!room) {
       throw new Error('Missing room for websocket replay');
     }
-    this.io.to(room).emit(eventName, data);
+    (this.io.to(room).emit as (event: string, data: unknown) => void)(eventName, data);
   }
 
-  /**
-   * Emit event when a new round starts
-   */
   /**
    * Emit event when a new round starts
    */

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -1,17 +1,31 @@
-import { Server as SocketIOServer, Socket } from 'socket.io';
 import { Server as HTTPServer } from 'http';
+import { Server as SocketIOServer } from 'socket.io';
+import type { DefaultEventsMap } from 'socket.io/dist/typed-events';
 import { verifyToken, verifyTokenDetailed } from './utils/jwt.util';
 import { prisma } from './lib/prisma';
 import websocketService from './services/websocket.service';
 import chatService from './services/chat.service';
 import multiplayerSessionService from './services/multiplayer-session.service';
-import { ChatMessage } from './types/chat.types';
 import logger from './utils/logger';
 import { initializeSocketAdapter } from './utils/socket-adapter';
 import {
    setSocketConnectionsActive,
    websocketConnectionEventsTotal,
 } from './metrics/application.metrics';
+import type {
+   TypedServer,
+   TypedSocket,
+   ServerToClientEvents,
+   ClientToServerEvents,
+   ServerHelloPayload,
+   AuthErrorPayload,
+   RoomEventPayload,
+   GenericErrorPayload,
+   ResumePayload,
+   ChatSendPayload,
+   ChatAckPayload,
+   SessionCheckpointPayload,
+} from './types/socket-events';
 
 const IS_PRODUCTION = process.env.NODE_ENV === 'production';
 
@@ -47,26 +61,13 @@ export function getCorsOrigins(): string | string[] {
    return clientUrl;
 }
 
-// Extended socket interface with user data
-interface AuthenticatedSocket extends Socket {
+// Extended socket with walletAddress attached directly alongside SocketData
+interface AuthenticatedSocket extends TypedSocket {
    userId?: string;
    walletAddress?: string;
    /** Unix epoch (ms) at which the JWT expires. */
    tokenExpiresAt?: number;
 }
-
-// Standardized ack payloads for chat:send
-type ChatAck =
-   | { ok: true; message: ChatMessage }
-   | {
-        ok: false;
-        error: string;
-        code:
-           | 'AUTH_REQUIRED'
-           | 'INVALID_CONTENT'
-           | 'RATE_LIMITED'
-           | 'SEND_FAILED';
-     };
 
 /**
  * In-memory sliding-window rate limiter for WebSocket events.
@@ -246,12 +247,13 @@ export function checkExpiredTokenSockets(
 
       const socket = io.sockets.sockets.get(socketId);
       if (socket) {
-         socket.emit('auth:error', {
+         const authErrorPayload: AuthErrorPayload = {
             code: AUTH_TOKEN_EXPIRED,
             message:
                'Your session token has expired. ' +
                'Refresh your access token and reconnect.',
-         });
+         };
+         socket.emit('auth:error', authErrorPayload);
          socket.disconnect(false);
       } else {
          connectionRegistry.delete(socketId);
@@ -299,10 +301,15 @@ export function checkExpiredTokenSockets(
  */
 export async function initializeSocket(
    httpServer: HTTPServer
-): Promise<SocketIOServer> {
+): Promise<TypedServer> {
    const corsOrigins = getCorsOrigins();
 
-   const io = new SocketIOServer(httpServer, {
+   const io = new SocketIOServer<
+      ClientToServerEvents,
+      ServerToClientEvents,
+      DefaultEventsMap,
+      import('./types/socket-events').SocketData
+   >(httpServer, {
       pingInterval: PING_INTERVAL,
       pingTimeout: PING_TIMEOUT,
       cors: {
@@ -418,13 +425,14 @@ export async function initializeSocket(
 
       // Announce the heartbeat contract so clients can tune their reconnect
       // logic. On reconnect, clients must re-join rooms explicitly.
-      socket.emit('server:hello', {
+      const helloPayload: ServerHelloPayload = {
          socketId: socket.id,
          pingInterval: PING_INTERVAL,
          pingTimeout: PING_TIMEOUT,
          authenticated: !!socket.userId,
          userId: socket.userId,
-      });
+      };
+      socket.emit('server:hello', helloPayload);
 
       // Refresh lastSeenAt on any incoming application-level event.
       socket.onAny(() => {
@@ -465,7 +473,7 @@ export async function initializeSocket(
                for (const room of resume.rooms) {
                   socket.join(room);
                }
-               socket.emit('session:resume', resume);
+               socket.emit('session:resume', resume as ResumePayload);
             })
             .catch(err => {
                logger.warn(
@@ -486,7 +494,8 @@ export async function initializeSocket(
          const room = roundId ? `round:${roundId}` : 'round';
          socket.join(room);
          logger.info(`Socket ${socket.id} joined room: ${room}`);
-         socket.emit('room:joined', { room });
+         const joinedPayload: RoomEventPayload = { room };
+         socket.emit('room:joined', joinedPayload);
          if (socket.userId) {
             void multiplayerSessionService.addRoom(socket.userId, room);
          }
@@ -502,25 +511,28 @@ export async function initializeSocket(
          }
 
          const room = roundId ? `round:${roundId}` : 'round';
-         socket.leave(room);
-         logger.info(`Socket ${socket.id} left room: ${room}`);
-         socket.emit('room:left', { room });
-         if (socket.userId) {
-            void multiplayerSessionService.removeRoom(socket.userId, room);
-         }
-      });
+          socket.leave(room);
+          logger.info(`Socket ${socket.id} left room: ${room}`);
+          const leftPayload: RoomEventPayload = { room };
+          socket.emit('room:left', leftPayload);
+          if (socket.userId) {
+             void multiplayerSessionService.removeRoom(socket.userId, room);
+          }
+       });
 
       // Join chat room (requires authentication)
       socket.on('join:chat', () => {
          if (!socket.userId) {
-            socket.emit('error', {
+            const errPayload: GenericErrorPayload = {
                message: 'Authentication required to join chat',
-            });
+            };
+            socket.emit('error', errPayload);
             return;
          }
          socket.join('chat');
          logger.info(`Socket ${socket.id} joined room: chat`);
-         socket.emit('room:joined', { room: 'chat' });
+         const joinedChat: RoomEventPayload = { room: 'chat' };
+         socket.emit('room:joined', joinedChat);
          void multiplayerSessionService.addRoom(socket.userId, 'chat');
       });
 
@@ -528,7 +540,8 @@ export async function initializeSocket(
       socket.on('leave:chat', () => {
          socket.leave('chat');
          logger.info(`Socket ${socket.id} left room: chat`);
-         socket.emit('room:left', { room: 'chat' });
+         const leftChat: RoomEventPayload = { room: 'chat' };
+         socket.emit('room:left', leftChat);
          if (socket.userId) {
             void multiplayerSessionService.removeRoom(socket.userId, 'chat');
          }
@@ -538,10 +551,10 @@ export async function initializeSocket(
       socket.on(
          'chat:send',
          async (
-            data: { content: string },
-            callback?: (ack: ChatAck) => void
+            data: ChatSendPayload,
+            callback?: (ack: ChatAckPayload) => void
          ) => {
-            const ack = (payload: ChatAck): void => {
+            const ack = (payload: ChatAckPayload): void => {
                if (typeof callback === 'function') callback(payload);
             };
 
@@ -608,13 +621,15 @@ export async function initializeSocket(
       // Join user notification room (for authenticated users)
       socket.on('join:notifications', () => {
          if (!socket.userId) {
-            socket.emit('error', {
+            const errPayload: GenericErrorPayload = {
                message: 'Authentication required for notifications',
-            });
+            };
+            socket.emit('error', errPayload);
             return;
          }
          socket.join(`user:${socket.userId}`);
-         socket.emit('room:joined', { room: 'notifications' });
+         const joinedNotif: RoomEventPayload = { room: 'notifications' };
+         socket.emit('room:joined', joinedNotif);
          void multiplayerSessionService.addRoom(
             socket.userId,
             `user:${socket.userId}`
@@ -623,7 +638,7 @@ export async function initializeSocket(
 
       // Issue #194: clients can checkpoint opaque session metadata
       // (e.g. last-viewed round, draft message) so it survives a reconnect.
-      socket.on('session:checkpoint', (patch: Record<string, unknown>) => {
+      socket.on('session:checkpoint', (patch: SessionCheckpointPayload) => {
          if (!socket.userId) return;
          if (!patch || typeof patch !== 'object' || Array.isArray(patch))
             return;

--- a/src/types/socket-events.ts
+++ b/src/types/socket-events.ts
@@ -1,0 +1,208 @@
+import type { Server, Socket } from 'socket.io';
+import type { DefaultEventsMap } from 'socket.io/dist/typed-events';
+import type { ChatMessage } from './chat.types';
+
+// ---------------------------------------------------------------------------
+// Server → Client event payloads
+// ---------------------------------------------------------------------------
+
+export interface ServerHelloPayload {
+  socketId: string;
+  pingInterval: number;
+  pingTimeout: number;
+  authenticated: boolean;
+  userId?: string;
+}
+
+export interface AuthErrorPayload {
+  code: 'AUTH_TOKEN_EXPIRED' | 'AUTH_TOKEN_INVALID';
+  message: string;
+}
+
+export interface RoomEventPayload {
+  room: string;
+}
+
+export interface GenericErrorPayload {
+  message: string;
+}
+
+export interface RoundStartedPayload {
+  id: string;
+  mode: string;
+  status: string;
+  startTime: unknown;
+  endTime: unknown;
+  startPrice: unknown;
+  priceRanges: unknown;
+}
+
+export interface PredictionPlacedPayload {
+  roundId: string;
+  predictionId: string;
+  amount: unknown;
+  side: unknown;
+  priceRange: unknown;
+}
+
+export interface RoundResolvedPayload {
+  id: string;
+  status: string;
+  startPrice: unknown;
+  endPrice: unknown;
+  resolvedAt: unknown;
+  predictions: number;
+  winners: number;
+}
+
+export interface PriceUpdatePayload {
+  asset: string;
+  price: number | string;
+  timestamp: string;
+}
+
+export interface RoundUpdatePayload {
+  id: string;
+  mode: string;
+  status: string;
+  startTime: string | null;
+  endTime: string | null;
+  startPrice: number | null;
+  endPrice: number | null;
+  poolUp: number;
+  poolDown: number;
+  priceRanges: unknown;
+  resolvedAt: string | null;
+}
+
+export interface NotificationNewPayload {
+  id: string;
+  type: string;
+  title: string;
+  message: string;
+  data: unknown;
+  isRead: boolean;
+  createdAt: string;
+}
+
+export interface UnreadCountPayload {
+  unreadCount: number;
+  timestamp: string;
+}
+
+// ---------------------------------------------------------------------------
+// Client → Server event payloads
+// ---------------------------------------------------------------------------
+
+export interface JoinRoundPayload {
+  roundId?: string;
+}
+
+export interface ChatSendPayload {
+  content: string;
+}
+
+export type ChatAckPayload =
+  | { ok: true; message: ChatMessage }
+  | {
+      ok: false;
+      error: string;
+      code: 'AUTH_REQUIRED' | 'INVALID_CONTENT' | 'RATE_LIMITED' | 'SEND_FAILED';
+    };
+
+export type SessionCheckpointPayload = Record<string, unknown>;
+
+// ---------------------------------------------------------------------------
+// Resume payload (re-exported from multiplayer-session.service)
+// ---------------------------------------------------------------------------
+
+export interface ResumePayload {
+  rooms: string[];
+  metadata: Record<string, unknown> | null;
+}
+
+// ---------------------------------------------------------------------------
+// Event map interfaces for typed Socket.IO
+// ---------------------------------------------------------------------------
+
+export interface ServerToClientEvents {
+  'server:hello': (data: ServerHelloPayload) => void;
+  'auth:error': (data: AuthErrorPayload) => void;
+  'room:joined': (data: RoomEventPayload) => void;
+  'room:left': (data: RoomEventPayload) => void;
+  'session:resume': (data: ResumePayload) => void;
+  error: (data: GenericErrorPayload) => void;
+
+  'round:started': (data: RoundStartedPayload) => void;
+  'prediction:placed': (data: PredictionPlacedPayload) => void;
+  'round:resolved': (data: RoundResolvedPayload) => void;
+  'price:update': (data: PriceUpdatePayload) => void;
+  'price_update': (data: PriceUpdatePayload) => void;
+  'chat:message': (data: ChatMessage) => void;
+  'notification:new': (data: NotificationNewPayload) => void;
+  'notification:unread-count': (data: UnreadCountPayload) => void;
+  'round_update': (data: RoundUpdatePayload) => void;
+}
+
+export interface ClientToServerEvents {
+  'join:round': (data?: JoinRoundPayload | string) => void;
+  'leave:round': (data?: JoinRoundPayload | string) => void;
+  'join:chat': () => void;
+  'leave:chat': () => void;
+  'chat:send': (data: ChatSendPayload, ack: (response: ChatAckPayload) => void) => void;
+  'join:notifications': () => void;
+  'session:checkpoint': (data: SessionCheckpointPayload) => void;
+}
+
+export interface SocketData {
+  userId?: string;
+  walletAddress?: string;
+  /** Unix epoch (ms) at which the JWT expires. */
+  tokenExpiresAt?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Typed Socket.IO server and socket aliases
+// ---------------------------------------------------------------------------
+
+export type TypedServer = Server<
+  ClientToServerEvents,
+  ServerToClientEvents,
+  DefaultEventsMap,
+  SocketData
+>;
+
+export type TypedSocket = Socket<
+  ClientToServerEvents,
+  ServerToClientEvents,
+  DefaultEventsMap,
+  SocketData
+>;
+
+// ---------------------------------------------------------------------------
+// Socket.IO client-side type for frontend consumption
+// ---------------------------------------------------------------------------
+
+/**
+ * Typed Socket.IO client for frontend consumption.
+ *
+ * Usage:
+ * ```typescript
+ * import { io } from 'socket.io-client';
+ * import type { TypedClientSocket } from '../../src/types/socket-events';
+ *
+ * const socket: TypedClientSocket = io('https://api.tevalabs.com', {
+ *   auth: { token: 'YOUR_JWT' },
+ * });
+ *
+ * socket.on('round:started', (data) => {
+ *   console.log(data.id); // fully typed
+ * });
+ *
+ * socket.emit('join:round', { roundId: 'abc' });
+ * ```
+ */
+export type TypedClientSocket = import('socket.io-client').Socket<
+  ServerToClientEvents,
+  ClientToServerEvents
+>;


### PR DESCRIPTION
Implement typed event maps and payload interfaces shared between server emits and client consumers.

src/types/socket-events.ts (new)
  - ServerToClientEvents — typed map of all 16 server→client events with their exact payload shapes
  - ClientToServerEvents — typed map of all 7 client→server events including ack callback types for chat:send
  - SocketData — socket.data shape (userId, walletAddress, tokenExpiresAt)
  - TypedServer / TypedSocket — typed Socket.IO server and socket aliases consuming the event maps
  - TypedClientSocket — client-side typed socket for frontend projects to import directly
  - Individual payload interfaces (ServerHelloPayload, RoundStartedPayload, PriceUpdatePayload, ChatAckPayload, etc.) for reuse in app code and docs

src/services/websocket.service.ts
  - Replace SocketIOServer with TypedServer (event-type-aware)
  - safeEmit now generic: <E extends WebSocketEventName> enforces at compile time that the payload matches the event
  - Internal emit uses a safe cast — the generic constraint on SafeEmitInput guarantees correctness at every call site
  - replayEmit retains its string-based signature (DLQ rows store eventName as text) with a looser emit cast

src/socket.ts
  - Socket.IO server instantiated with ClientToServerEvents/ServerToClientEvents/SocketData generics
  - All socket.emit() calls use typed payload variables (ServerHelloPayload, AuthErrorPayload, RoomEventPayload, GenericErrorPayload) instead of inline object literals
  - chat:send handler types data as ChatSendPayload and ack as ChatAckPayload
  - session:checkpoint handler uses SessionCheckpointPayload
  - Removed local ChatAck union type — replaced by imported ChatAckPayload
  - Unused direct ChatMessage import removed

src/docs/websocket.md
  - Full rewrite documenting every event with its typed payload interface
  - Added frontend usage example with TypedClientSocket import
  - Links to src/types/socket-events.ts as the authoritative contract source
  - Documents heartbeat, token expiry, reconnect continuity, and all client→server / server→client events

Build: lint + build pass with zero new errors (all 10 pre-existing errors are in unrelated files: mockData, rateLimiter, leaderboard, rounds).

Closes #429 