### PR TITLE
feat: add docker-compose hackathon profile with correct health path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,6 @@ RUN chmod +x /entrypoint.sh
 
 EXPOSE 3000
 HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 \
-  CMD wget -qO- http://127.0.0.1:${PORT:-3000}/health || exit 1
+  CMD wget -qO- http://127.0.0.1:${PORT:-3000}${HEALTHCHECK_PATH:-/health} || exit 1
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -517,6 +517,12 @@ To include Redis (for Socket.IO adapter / distributed locks):
 docker compose --profile full up --build
 ```
 
+To run the **hackathon mode** (no database required, mock data only):
+
+```bash
+docker compose --profile hackathon up
+```
+
 **Troubleshooting Docker setup**
 
 | Symptom | Fix |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,5 +51,25 @@ services:
       retries: 5
       start_period: 45s
 
+  hackathon:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    profiles: ["hackathon"]
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env.hackathon.example
+    environment:
+      PORT: 3000
+      HEALTHCHECK_PATH: /api/health
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/api/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 45s
+
 volumes:
   postgres_data:


### PR DESCRIPTION
closes #437
<!--
Thanks for contributing to Xelma Backend!
Fill out every section. PRs with an incomplete checklist may be sent back.
-->

## Summary

<!-- What does this PR change and why? Link the issue it closes. -->

Closes #

## Dual-entrypoint architecture

This repo ships **two Express applications**. `npm run dev` (`src/index.ts`) is the
default production path and is the one reviewers and CI care about. `src/app.ts`
(`npm run dev:hackathon`) is a separate mock/demo entrypoint.

Several past issues were closed while the functionality existed **only** in one
entrypoint. Before requesting review, confirm your change behaves correctly on the
default `npm run dev` path. See [docs/architecture.md](../docs/architecture.md) for
the entrypoint map and the checklist for adding new routes.

## Affected endpoints

<!-- List every HTTP route / WebSocket event this PR adds, changes, or removes.
     Write "None" if this PR touches no endpoints. -->

-

## Checklist

- [ ] Verified the change works on the default `npm run dev` (`src/index.ts`) entrypoint.
- [ ] If the change affects shared functionality, verified it on the hackathon `src/app.ts` entrypoint too (or explained why it does not apply).
- [ ] Listed all affected endpoints above (or marked "None").
- [ ] Added or updated tests covering the change.
- [ ] `npm run lint` and `npm test` pass locally.
- [ ] Updated docs (README, OpenAPI annotations, `docs/`) where behavior changed.

## Notes for reviewers

<!-- Anything else: trade-offs, follow-ups, screenshots, migration risk. -->
