### PR TITLE
test: add tournament route and service test suite (closes #412)

### DIFF
--- a/src/tests/tournament.service.spec.ts
+++ b/src/tests/tournament.service.spec.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, afterEach } from '@jest/globals';
+import { NotFoundError, ConflictError, ValidationError } from '../utils/errors';
+
+const mockTournamentFindUnique = jest.fn();
+const mockTournamentUpdate = jest.fn();
+const mockParticipantFindUnique = jest.fn();
+const mockParticipantCreate = jest.fn();
+const mockTransaction = jest.fn();
+
+jest.mock('../lib/prisma', () => ({
+  prisma: {
+    tournament: {
+      findUnique: (...args: any[]) => mockTournamentFindUnique(...args),
+      update: (...args: any[]) => mockTournamentUpdate(...args),
+    },
+    tournamentParticipant: {
+      findUnique: (...args: any[]) => mockParticipantFindUnique(...args),
+      create: (...args: any[]) => mockParticipantCreate(...args),
+    },
+    $transaction: (...args: any[]) => mockTransaction(...args),
+  },
+}));
+
+// Imported after the mock so the service picks up the mocked prisma client.
+import tournamentService from '../services/tournament.service';
+
+const baseTournament = {
+  id: 't-001',
+  status: 'ACTIVE',
+  currentParticipants: 5,
+  maxParticipants: 10,
+};
+
+describe('TournamentService.joinTournament (Issue #412)', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('throws NotFoundError when the tournament does not exist', async () => {
+    mockTournamentFindUnique.mockResolvedValueOnce(null);
+
+    await expect(
+      tournamentService.joinTournament('user-1', 't-missing'),
+    ).rejects.toBeInstanceOf(NotFoundError);
+
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it('throws ValidationError when the tournament is cancelled', async () => {
+    mockTournamentFindUnique.mockResolvedValueOnce({ ...baseTournament, status: 'CANCELLED' });
+
+    await expect(
+      tournamentService.joinTournament('user-1', 't-001'),
+    ).rejects.toBeInstanceOf(ValidationError);
+
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it('throws ConflictError when the tournament is full', async () => {
+    mockTournamentFindUnique.mockResolvedValueOnce({
+      ...baseTournament,
+      currentParticipants: 10,
+      maxParticipants: 10,
+    });
+
+    await expect(
+      tournamentService.joinTournament('user-1', 't-001'),
+    ).rejects.toBeInstanceOf(ConflictError);
+
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it('throws ConflictError when the user already joined', async () => {
+    mockTournamentFindUnique.mockResolvedValueOnce(baseTournament);
+    mockParticipantFindUnique.mockResolvedValueOnce({
+      tournamentId: 't-001',
+      userId: 'user-1',
+    });
+
+    await expect(
+      tournamentService.joinTournament('user-1', 't-001'),
+    ).rejects.toBeInstanceOf(ConflictError);
+
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it('joins successfully and returns the updated participant count', async () => {
+    mockTournamentFindUnique.mockResolvedValueOnce(baseTournament);
+    mockParticipantFindUnique.mockResolvedValueOnce(null);
+    mockTransaction.mockResolvedValueOnce([
+      { tournamentId: 't-001', userId: 'user-1' },
+      { ...baseTournament, currentParticipants: 6 },
+    ]);
+
+    const result = await tournamentService.joinTournament('user-1', 't-001');
+
+    expect(result).toEqual({ currentParticipants: 6 });
+    expect(mockTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('checks tournament status/capacity before checking existing membership', async () => {
+    mockTournamentFindUnique.mockResolvedValueOnce({
+      ...baseTournament,
+      currentParticipants: 10,
+      maxParticipants: 10,
+    });
+
+    await expect(
+      tournamentService.joinTournament('user-1', 't-001'),
+    ).rejects.toBeInstanceOf(ConflictError);
+
+    expect(mockParticipantFindUnique).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/tournaments.routes.spec.ts
+++ b/src/tests/tournaments.routes.spec.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, afterEach } from '@jest/globals';
+import request from 'supertest';
+import { Express } from 'express';
+import { createApp } from '../index';
+import { generateToken } from '../utils/jwt.util';
+import { UserRole } from '@prisma/client';
+
+const mockJoinTournament = jest.fn();
+const mockUserFindUnique = jest.fn();
+
+jest.mock('../lib/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: (...args: any[]) => mockUserFindUnique(...args),
+    },
+    $disconnect: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock('../services/tournament.service', () => ({
+  __esModule: true,
+  default: {
+    joinTournament: (...args: any[]) => mockJoinTournament(...args),
+  },
+}));
+
+jest.mock('../middleware/rateLimiter.middleware', () => ({
+  challengeRateLimiter: (_req: any, _res: any, next: any) => next(),
+  connectRateLimiter: (_req: any, _res: any, next: any) => next(),
+  authRateLimiter: (_req: any, _res: any, next: any) => next(),
+  chatMessageRateLimiter: (_req: any, _res: any, next: any) => next(),
+  adminRoundRateLimiter: (_req: any, _res: any, next: any) => next(),
+  oracleResolveRateLimiter: (_req: any, _res: any, next: any) => next(),
+  predictionRateLimiter: (_req: any, _res: any, next: any) => next(),
+  batchPredictionRateLimiter: (_req: any, _res: any, next: any) => next(),
+  batchLeaderboardRateLimiter: (_req: any, _res: any, next: any) => next(),
+}));
+
+describe('Tournaments Routes (Issue #412)', () => {
+  const app: Express = createApp();
+  const userId = 'tourney-user-id';
+  const walletAddress = 'GUSER_TOURNEY_TEST_AAAAAAAAAAAAAA';
+  const token = generateToken(userId, walletAddress, UserRole.USER);
+
+  beforeEach(() => {
+    mockUserFindUnique.mockResolvedValue({ id: userId, walletAddress, role: UserRole.USER });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('GET /api/tournaments', () => {
+    it('returns the default paginated list', async () => {
+      const res = await request(app).get('/api/tournaments');
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(Array.isArray(res.body.data)).toBe(true);
+      expect(res.body.data.length).toBe(3);
+      expect(res.body.pagination.total).toBe(3);
+    });
+
+    it('filters by status (case-insensitive)', async () => {
+      const res = await request(app).get('/api/tournaments').query({ status: 'active' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.every((t: any) => t.status === 'ACTIVE')).toBe(true);
+      expect(res.body.pagination.total).toBe(1);
+    });
+
+    it('returns an empty list for a status with no matches', async () => {
+      const res = await request(app).get('/api/tournaments').query({ status: 'cancelled' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual([]);
+      expect(res.body.pagination.total).toBe(0);
+    });
+
+    it('applies limit and offset', async () => {
+      const res = await request(app).get('/api/tournaments').query({ limit: 1, offset: 1 });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(1);
+      expect(res.body.pagination).toEqual({ limit: 1, offset: 1, total: 3 });
+    });
+
+    it('rejects an invalid (negative) limit', async () => {
+      const res = await request(app).get('/api/tournaments').query({ limit: -1 });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('GET /api/tournaments/:id', () => {
+    it('returns tournament detail for a known id', async () => {
+      const res = await request(app).get('/api/tournaments/t-001');
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.id).toBe('t-001');
+    });
+
+    it('returns 404 for an unknown id', async () => {
+      const res = await request(app).get('/api/tournaments/does-not-exist');
+
+      expect(res.status).toBe(404);
+      expect(res.body.message ?? res.body.error?.message).toMatch(/not found/i);
+    });
+  });
+
+  describe('POST /api/tournaments/:id/join', () => {
+    it('requires authentication', async () => {
+      const res = await request(app).post('/api/tournaments/t-001/join');
+
+      expect(res.status).toBe(401);
+      expect(mockJoinTournament).not.toHaveBeenCalled();
+    });
+
+    it('joins successfully and returns updated participant count', async () => {
+      mockJoinTournament.mockResolvedValueOnce({ currentParticipants: 68 });
+
+      const res = await request(app)
+        .post('/api/tournaments/t-001/join')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toEqual({ tournamentId: 't-001', currentParticipants: 68 });
+      expect(mockJoinTournament).toHaveBeenCalledWith(userId, 't-001');
+    });
+
+    it('propagates a 404 when the service reports tournament not found', async () => {
+      const { NotFoundError } = require('../utils/errors');
+      mockJoinTournament.mockRejectedValueOnce(new NotFoundError('Tournament not found'));
+
+      const res = await request(app)
+        .post('/api/tournaments/unknown-id/join')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(404);
+    });
+
+    it('propagates a 409 when the tournament is full', async () => {
+      const { ConflictError } = require('../utils/errors');
+      mockJoinTournament.mockRejectedValueOnce(new ConflictError('Tournament is full'));
+
+      const res = await request(app)
+        .post('/api/tournaments/t-001/join')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(409);
+    });
+
+    it('propagates a 409 when the user already joined', async () => {
+      const { ConflictError } = require('../utils/errors');
+      mockJoinTournament.mockRejectedValueOnce(new ConflictError('Already joined this tournament'));
+
+      const res = await request(app)
+        .post('/api/tournaments/t-001/join')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(409);
+    });
+
+    it('propagates a 400 when the tournament is cancelled', async () => {
+      const { ValidationError } = require('../utils/errors');
+      mockJoinTournament.mockRejectedValueOnce(new ValidationError('Tournament is cancelled'));
+
+      const res = await request(app)
+        .post('/api/tournaments/t-001/join')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(400);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Closes #412. Adds a dedicated test suite for the tournament feature — HTTP-level tests for the routes and unit tests for the service — since tournaments previously shipped without coverage, which is how the split-brain bugs mentioned in the issue went unnoticed.

## What's covered

**`src/tests/tournaments.routes.spec.ts`** — HTTP layer
- `GET /api/tournaments`
  - default paginated list
  - status filter, case-insensitive
  - empty result set for a status with no matches
  - limit/offset pagination
  - rejects an invalid (negative) limit
- `GET /api/tournaments/:id`
  - returns detail for a known id
  - 404 for an unknown id
- `POST /api/tournaments/:id/join`
  - 401 when unauthenticated
  - 200 + updated participant count on success
  - 404 when the tournament doesn't exist
  - 409 when the tournament is full
  - 409 when the user already joined
  - 400 when the tournament is cancelled

**`src/tests/tournament.service.spec.ts`** — service layer, mocked Prisma
- `joinTournament` against every branch: not found, cancelled, full, already-joined, success
- confirms status/capacity checks run before the existing-membership lookup
- confirms `$transaction` is never called when a pre-check fails

## Testing

npx jest --testPathPattern="tournament"

Both suites green — 19/19 passing.

## Notes
- No live database needed. Both suites mock `../lib/prisma`, matching the existing convention in `rounds.routes.spec.ts`.
- No production code was changed — this is test coverage only.