### PR TITLE
feat: expose Prometheus metrics on hackathon entrypoint

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,8 @@ import { apiRateLimiter, writeRateLimiter } from './middleware/rateLimiter';
 import { getHttpCorsOrigins } from './utils/cors';
 import { notFoundHandler } from './middleware/notFound'; // Ensure this file exists and outputs JSON
 import { errorHandler } from './middleware/errorHandler';
+import { metricsMiddleware } from './middleware/metrics.middleware';
+import metricsRoutes from './routes/metrics.routes';
 import { hackathonSwaggerSpec } from './docs/hackathon-openapi';
 import config from './config';
 import logger from './utils/logger';
@@ -43,6 +45,9 @@ export function createApp(options: CreateAppOptions = {}): Application {
   // Assign a correlation ID to every request and expose it on the response header
   app.use(requestIdMiddleware);
 
+  // Prometheus metrics middleware (before routes so all requests are tracked)
+  app.use(metricsMiddleware);
+
   // Structured Winston HTTP request logging with duration and correlation ID
   app.use((req: Request, res: Response, next: NextFunction) => {
     const startMs = Date.now();
@@ -63,6 +68,9 @@ export function createApp(options: CreateAppOptions = {}): Application {
   app.get('/docs', (_req, res) => res.redirect(302, '/api-docs'));
   app.get('/api-docs.json', (_req, res) => res.json(hackathonSwaggerSpec));
   app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(hackathonSwaggerSpec, { explorer: true }));
+
+  // Prometheus metrics endpoint
+  app.use('/metrics', metricsRoutes);
 
   app.use('/api', apiRateLimiter);
   app.use('/api', writeRateLimiter);

--- a/src/docs/hackathon-openapi.ts
+++ b/src/docs/hackathon-openapi.ts
@@ -150,6 +150,7 @@ export const hackathonSwaggerSpec = swaggerJSDoc({
       { name: 'rounds', description: 'Mock prediction rounds' },
       { name: 'leaderboard', description: 'Mock leaderboard data' },
       { name: 'tournaments', description: 'Tournament listings and join' },
+      { name: 'observability', description: 'Prometheus metrics and readiness probes' },
     ],
   },
   apis: [

--- a/src/security/route-parity.registry.ts
+++ b/src/security/route-parity.registry.ts
@@ -19,8 +19,6 @@ export const VERSIONED_ALIAS_ALLOWLIST: string[] = ["GET /price"];
 export const PARITY_ALLOWLIST: ParityAllowlistEntry[] = [
   { method: "GET", path: "/", only: "main", reason: "Root welcome banner is production-only." },
   { method: "GET", path: "/health", only: "main", reason: "Production health probe is mounted at /health; the hackathon app mounts it under /api." },
-  { method: "GET", path: "/metrics", only: "main", reason: "Prometheus metrics are production-only." },
-  { method: "GET", path: "/metrics/readiness", only: "main", reason: "Schema readiness probe is production-only." },
   { method: "GET", path: "/api/price", only: "main", reason: "Production single-asset XLM price endpoint; the hackathon app serves /api/prices instead." },
   { method: "GET", path: "/api/errors", only: "main", reason: "Production error catalog is not part of the mock demo." },
   { method: "POST", path: "/api/auth/challenge", only: "main", reason: "Wallet auth flow is not part of the mock demo." },


### PR DESCRIPTION
## Summary

- Mount `metricsMiddleware` and the `/metrics` scrape endpoint on the hackathon Express app so Prometheus operators can scrape hackathon deploys instead of getting silent 404s.
- Remove `/metrics` and `/metrics/readiness` from the main-only parity allowlist since both apps now serve these endpoints.
- Add `observability` tag to the hackathon OpenAPI spec.

## Changes

| File | What changed |
|---|---|
| `src/app.ts` | Import and apply `metricsMiddleware` + `metricsRoutes` |
| `src/security/route-parity.registry.ts` | Remove 2 stale `only: "main"` entries for `/metrics` and `/metrics/readiness` |
| `src/docs/hackathon-openapi.ts` | Add `observability` tag |

## Why

Operators scraping hackathon deploys currently get confusion/404s when hitting `/metrics`. This makes the hackathon observability story intentional and consistent with the production app.

Closes #424