### PR TITLE
fix(auth): require Stellar JWT on hackathon bet mutation endpoints (#399)

### DIFF
--- a/src/routes/rounds.ts
+++ b/src/routes/rounds.ts
@@ -1,6 +1,10 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { betRateLimiter } from '../middleware/rateLimiter';
 import { validate } from '../middleware/validate.middleware';
+import {
+  verifyStellarAuth,
+  bindAuthenticatedWallet,
+} from '../middleware/auth.middleware';
 import { sendSuccess } from '../utils/response';
 import { betSchema, upDownBetSchema, precisionBetSchema } from '../schemas/bets.schema';
 
@@ -72,32 +76,57 @@ router.get('/', async (_req: Request, res: Response, next: NextFunction) => {
   }
 });
 
+// Hackathon bet mutation endpoints — protect with the same Stellar JWT auth
+// used by /api/bets/*. The middleware chain enforces in this order:
+//   1. verifyStellarAuth    — reject when no/invalid Bearer token (401)
+//   2. bindAuthenticatedWallet — reject when body address does not match
+//      the JWT-authenticated wallet, and normalize req.body.address to the
+//      authenticated wallet so downstream handlers cannot be tricked.
+//   3. validate(schema)     — Zod validation of type-safe numeric fields.
+// Closes #399: demo bet APIs are no longer unauthenticated relays.
+const hackathonBetAuth = [
+  verifyStellarAuth,
+  bindAuthenticatedWallet,
+] as const;
+
 // TODO: Call contract via Xelma TypeScript bindings — bets must go on-chain; this endpoint is logging/analytics only for now
-router.post('/:id/bet', betRateLimiter, validate(betSchema), (_req, res) => {
+router.post('/:id/bet', betRateLimiter, ...hackathonBetAuth, validate(betSchema), (_req, res) => {
   res.json({ success: true, message: 'Bet recorded (stub)' });
 });
 
 // Hackathon mutation endpoints - with Zod validation for consistent error handling
-router.post('/hackathon/up-down/:id/bet', betRateLimiter, validate(upDownBetSchema), (async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const { id } = req.params;
-    const { address, amount, side } = req.body;
-    await getRepositories().rounds.placeBet(id, address, amount, side);
-    sendSuccess(res, { message: 'Bet recorded (stub)' });
-  } catch (err) {
-    next(err);
-  }
-}) as any);
+router.post(
+  '/hackathon/up-down/:id/bet',
+  betRateLimiter,
+  ...hackathonBetAuth,
+  validate(upDownBetSchema),
+  (async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { id } = req.params;
+      const { address, amount, side } = req.body;
+      await getRepositories().rounds.placeBet(id, address, amount, side);
+      sendSuccess(res, { message: 'Bet recorded (stub)' });
+    } catch (err) {
+      next(err);
+    }
+  }) as any,
+);
 
-router.post('/hackathon/precision/:id/bet', betRateLimiter, validate(precisionBetSchema), (async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const { id } = req.params;
-    const { address, amount, predictedPrice } = req.body;
-    await getRepositories().rounds.placeBet(id, address, amount, undefined, predictedPrice);
-    sendSuccess(res, { message: 'Precision bet recorded (stub)' });
-  } catch (err) {
-    next(err);
-  }
-}) as any);
+router.post(
+  '/hackathon/precision/:id/bet',
+  betRateLimiter,
+  ...hackathonBetAuth,
+  validate(precisionBetSchema),
+  (async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { id } = req.params;
+      const { address, amount, predictedPrice } = req.body;
+      await getRepositories().rounds.placeBet(id, address, amount, undefined, predictedPrice);
+      sendSuccess(res, { message: 'Precision bet recorded (stub)' });
+    } catch (err) {
+      next(err);
+    }
+  }) as any,
+);
 
 export default router;

--- a/src/tests/hackathon-bets.routes.spec.ts
+++ b/src/tests/hackathon-bets.routes.spec.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import { describe, it, expect, beforeEach, afterEach, beforeAll } from "@jest/globals";
 import request from "supertest";
 import { Express } from "express";
+import { UserRole } from "@prisma/client";
 import { createApp } from "../app";
+import { generateToken } from "../utils/jwt.util";
 
 jest.mock("../middleware/rateLimiter", () => {
   const mockMiddleware = (req: any, res: any, next: any) => next();
@@ -25,18 +27,31 @@ jest.mock("../services/hackathon.service", () => {
 });
 
 const VALID_ADDRESS = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+const OTHER_ADDRESS = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBZ";
 
-describe("Hackathon Bet Routes - Zod validation", () => {
+describe("Hackathon Bet Routes - Auth + Zod validation", () => {
   let app: Express;
+  let token: string;
+
+  beforeAll(() => {
+    app = createApp();
+    token = generateToken("hackathon-user-1", VALID_ADDRESS, UserRole.USER);
+  });
 
   beforeEach(() => {
+    // createApp is memoized across tests; recreate so mocks reset cleanly.
     app = createApp();
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe("POST /api/rounds/hackathon/up-down/:id/bet", () => {
-    it("should return 200 for valid UP/DOWN bet payload", async () => {
+    it("returns 200 for valid UP/DOWN bet payload with matching JWT wallet", async () => {
       const res = await request(app)
         .post("/api/rounds/hackathon/up-down/test-round/bet")
+        .set("Authorization", `Bearer ${token}`)
         .send({ address: VALID_ADDRESS, amount: 10, side: "UP" });
 
       expect(res.status).toBe(200);
@@ -46,9 +61,62 @@ describe("Hackathon Bet Routes - Zod validation", () => {
       });
     });
 
-    it("should return 400 for missing required fields", async () => {
+    it("returns 200 when the body omits address (bound to authenticated wallet)", async () => {
       const res = await request(app)
         .post("/api/rounds/hackathon/up-down/test-round/bet")
+        .set("Authorization", `Bearer ${token}`)
+        .send({ amount: 10, side: "UP" });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        success: true,
+        message: "Bet recorded (stub)",
+      });
+    });
+
+    it("returns 401 when no Authorization header is provided", async () => {
+      const res = await request(app)
+        .post("/api/rounds/hackathon/up-down/test-round/bet")
+        .send({ address: VALID_ADDRESS, amount: 10, side: "UP" });
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("No token provided");
+    });
+
+    it("returns 401 when Bearer token is malformed (missing token part)", async () => {
+      const res = await request(app)
+        .post("/api/rounds/hackathon/up-down/test-round/bet")
+        .set("Authorization", "Bearer ")
+        .send({ address: VALID_ADDRESS, amount: 10, side: "UP" });
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("No token provided");
+    });
+
+    it("returns 401 when the JWT is invalid or expired", async () => {
+      const res = await request(app)
+        .post("/api/rounds/hackathon/up-down/test-round/bet")
+        .set("Authorization", "Bearer invalid.jwt.token")
+        .send({ address: VALID_ADDRESS, amount: 10, side: "UP" });
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Invalid or expired token");
+    });
+
+    it("returns 403 when body address does not match the authenticated wallet", async () => {
+      const res = await request(app)
+        .post("/api/rounds/hackathon/up-down/test-round/bet")
+        .set("Authorization", `Bearer ${token}`)
+        .send({ address: OTHER_ADDRESS, amount: 10, side: "UP" });
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toMatch(/match authenticated user/i);
+    });
+
+    it("returns 400 for missing required fields (auth passes first)", async () => {
+      const res = await request(app)
+        .post("/api/rounds/hackathon/up-down/test-round/bet")
+        .set("Authorization", `Bearer ${token}`)
         .send({ address: VALID_ADDRESS, amount: 10 });
 
       expect(res.status).toBe(400);
@@ -59,9 +127,10 @@ describe("Hackathon Bet Routes - Zod validation", () => {
       expect(Array.isArray(res.body.details)).toBe(true);
     });
 
-    it("should return 400 for invalid side value", async () => {
+    it("returns 400 for invalid side value", async () => {
       const res = await request(app)
         .post("/api/rounds/hackathon/up-down/test-round/bet")
+        .set("Authorization", `Bearer ${token}`)
         .send({ address: VALID_ADDRESS, amount: 10, side: "INVALID" });
 
       expect(res.status).toBe(400);
@@ -70,9 +139,10 @@ describe("Hackathon Bet Routes - Zod validation", () => {
       expect(res.body.message).toBeDefined();
     });
 
-    it("should return 400 for negative amount", async () => {
+    it("returns 400 for negative amount", async () => {
       const res = await request(app)
         .post("/api/rounds/hackathon/up-down/test-round/bet")
+        .set("Authorization", `Bearer ${token}`)
         .send({ address: VALID_ADDRESS, amount: -5, side: "UP" });
 
       expect(res.status).toBe(400);
@@ -80,9 +150,10 @@ describe("Hackathon Bet Routes - Zod validation", () => {
       expect(res.body.code).toBe("VALIDATION_ERROR");
     });
 
-    it("should return 400 for zero amount", async () => {
+    it("returns 400 for zero amount", async () => {
       const res = await request(app)
         .post("/api/rounds/hackathon/up-down/test-round/bet")
+        .set("Authorization", `Bearer ${token}`)
         .send({ address: VALID_ADDRESS, amount: 0, side: "UP" });
 
       expect(res.status).toBe(400);
@@ -90,21 +161,26 @@ describe("Hackathon Bet Routes - Zod validation", () => {
       expect(res.body.code).toBe("VALIDATION_ERROR");
     });
 
-    it("should return 400 for invalid address format", async () => {
+    it("returns 403 when body address is not a valid Stellar format", async () => {
+      // bindAuthenticatedWallet runs before validate, so an invalid-format
+      // address (which cannot match the Stellar-format JWT wallet) is rejected
+      // with 403 earlier than Zod's 400. The 403-mismatch happy-path test
+      // above already covers the user-imperonation intent (OTHER_ADDRESS).
       const res = await request(app)
         .post("/api/rounds/hackathon/up-down/test-round/bet")
+        .set("Authorization", `Bearer ${token}`)
         .send({ address: "INVALID_ADDRESS", amount: 10, side: "UP" });
 
-      expect(res.status).toBe(400);
-      expect(res.body.error).toBe("ValidationError");
-      expect(res.body.code).toBe("VALIDATION_ERROR");
+      expect(res.status).toBe(403);
+      expect(res.body.error).toMatch(/match authenticated user/i);
     });
   });
 
   describe("POST /api/rounds/hackathon/precision/:id/bet", () => {
-    it("should return 200 for valid Precision bet payload", async () => {
+    it("returns 200 for valid Precision bet payload with matching JWT wallet", async () => {
       const res = await request(app)
         .post("/api/rounds/hackathon/precision/test-round/bet")
+        .set("Authorization", `Bearer ${token}`)
         .send({ address: VALID_ADDRESS, amount: 5, predictedPrice: 0.12 });
 
       expect(res.status).toBe(200);
@@ -114,9 +190,42 @@ describe("Hackathon Bet Routes - Zod validation", () => {
       });
     });
 
-    it("should return 400 for missing predictedPrice", async () => {
+    it("returns 200 when body omits address (bound to authenticated wallet)", async () => {
       const res = await request(app)
         .post("/api/rounds/hackathon/precision/test-round/bet")
+        .set("Authorization", `Bearer ${token}`)
+        .send({ amount: 5, predictedPrice: 0.12 });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        success: true,
+        message: "Precision bet recorded (stub)",
+      });
+    });
+
+    it("returns 401 when no Authorization header is provided", async () => {
+      const res = await request(app)
+        .post("/api/rounds/hackathon/precision/test-round/bet")
+        .send({ address: VALID_ADDRESS, amount: 5, predictedPrice: 0.12 });
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("No token provided");
+    });
+
+    it("returns 403 when body address does not match the authenticated wallet", async () => {
+      const res = await request(app)
+        .post("/api/rounds/hackathon/precision/test-round/bet")
+        .set("Authorization", `Bearer ${token}`)
+        .send({ address: OTHER_ADDRESS, amount: 5, predictedPrice: 0.12 });
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toMatch(/match authenticated user/i);
+    });
+
+    it("returns 400 for missing predictedPrice", async () => {
+      const res = await request(app)
+        .post("/api/rounds/hackathon/precision/test-round/bet")
+        .set("Authorization", `Bearer ${token}`)
         .send({ address: VALID_ADDRESS, amount: 5 });
 
       expect(res.status).toBe(400);
@@ -124,9 +233,10 @@ describe("Hackathon Bet Routes - Zod validation", () => {
       expect(res.body.code).toBe("VALIDATION_ERROR");
     });
 
-    it("should return 400 for zero predictedPrice", async () => {
+    it("returns 400 for zero predictedPrice", async () => {
       const res = await request(app)
         .post("/api/rounds/hackathon/precision/test-round/bet")
+        .set("Authorization", `Bearer ${token}`)
         .send({ address: VALID_ADDRESS, amount: 5, predictedPrice: 0 });
 
       expect(res.status).toBe(400);
@@ -134,9 +244,10 @@ describe("Hackathon Bet Routes - Zod validation", () => {
       expect(res.body.code).toBe("VALIDATION_ERROR");
     });
 
-    it("should return 400 for negative predictedPrice", async () => {
+    it("returns 400 for negative predictedPrice", async () => {
       const res = await request(app)
         .post("/api/rounds/hackathon/precision/test-round/bet")
+        .set("Authorization", `Bearer ${token}`)
         .send({ address: VALID_ADDRESS, amount: 5, predictedPrice: -1 });
 
       expect(res.status).toBe(400);
@@ -144,9 +255,10 @@ describe("Hackathon Bet Routes - Zod validation", () => {
       expect(res.body.code).toBe("VALIDATION_ERROR");
     });
 
-    it("should return 400 for non-numeric predictedPrice", async () => {
+    it("returns 400 for non-numeric predictedPrice", async () => {
       const res = await request(app)
         .post("/api/rounds/hackathon/precision/test-round/bet")
+        .set("Authorization", `Bearer ${token}`)
         .send({ address: VALID_ADDRESS, amount: 5, predictedPrice: "invalid" });
 
       expect(res.status).toBe(400);
@@ -156,9 +268,10 @@ describe("Hackathon Bet Routes - Zod validation", () => {
   });
 
   describe("POST /api/rounds/:id/bet (generic stub)", () => {
-    it("should return 200 for valid UP/DOWN payload", async () => {
+    it("returns 200 for valid UP/DOWN payload with valid JWT", async () => {
       const res = await request(app)
         .post("/api/rounds/round-1/bet")
+        .set("Authorization", `Bearer ${token}`)
         .send({ address: VALID_ADDRESS, amount: 10, side: "UP" });
 
       expect(res.status).toBe(200);
@@ -168,9 +281,10 @@ describe("Hackathon Bet Routes - Zod validation", () => {
       });
     });
 
-    it("should return 200 for valid Precision payload", async () => {
+    it("returns 200 for valid Precision payload with valid JWT", async () => {
       const res = await request(app)
         .post("/api/rounds/round-1/bet")
+        .set("Authorization", `Bearer ${token}`)
         .send({ address: VALID_ADDRESS, amount: 5, predictedPrice: 0.12 });
 
       expect(res.status).toBe(200);
@@ -180,9 +294,29 @@ describe("Hackathon Bet Routes - Zod validation", () => {
       });
     });
 
-    it("should return 400 for empty body", async () => {
+    it("returns 401 when no Authorization header is provided", async () => {
       const res = await request(app)
         .post("/api/rounds/round-1/bet")
+        .send({ address: VALID_ADDRESS, amount: 10, side: "UP" });
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("No token provided");
+    });
+
+    it("returns 403 when body address does not match the authenticated wallet", async () => {
+      const res = await request(app)
+        .post("/api/rounds/round-1/bet")
+        .set("Authorization", `Bearer ${token}`)
+        .send({ address: OTHER_ADDRESS, amount: 10, side: "UP" });
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toMatch(/match authenticated user/i);
+    });
+
+    it("returns 400 for empty body (after auth)", async () => {
+      const res = await request(app)
+        .post("/api/rounds/round-1/bet")
+        .set("Authorization", `Bearer ${token}`)
         .send({});
 
       expect(res.status).toBe(400);
@@ -191,9 +325,10 @@ describe("Hackathon Bet Routes - Zod validation", () => {
       expect(res.body.details).toBeDefined();
     });
 
-    it("should return 400 for missing required fields", async () => {
+    it("returns 400 for missing required fields", async () => {
       const res = await request(app)
         .post("/api/rounds/round-1/bet")
+        .set("Authorization", `Bearer ${token}`)
         .send({ address: VALID_ADDRESS, amount: 10 });
 
       expect(res.status).toBe(400);
@@ -201,9 +336,10 @@ describe("Hackathon Bet Routes - Zod validation", () => {
       expect(res.body.code).toBe("VALIDATION_ERROR");
     });
 
-    it("should return 400 for invalid side value", async () => {
+    it("returns 400 for invalid side value", async () => {
       const res = await request(app)
         .post("/api/rounds/round-1/bet")
+        .set("Authorization", `Bearer ${token}`)
         .send({ address: VALID_ADDRESS, amount: 10, side: "INVALID" });
 
       expect(res.status).toBe(400);
@@ -211,9 +347,10 @@ describe("Hackathon Bet Routes - Zod validation", () => {
       expect(res.body.code).toBe("VALIDATION_ERROR");
     });
 
-    it("should return 400 for negative amount", async () => {
+    it("returns 400 for negative amount", async () => {
       const res = await request(app)
         .post("/api/rounds/round-1/bet")
+        .set("Authorization", `Bearer ${token}`)
         .send({ address: VALID_ADDRESS, amount: -5, side: "UP" });
 
       expect(res.status).toBe(400);
@@ -221,14 +358,18 @@ describe("Hackathon Bet Routes - Zod validation", () => {
       expect(res.body.code).toBe("VALIDATION_ERROR");
     });
 
-    it("should return 400 for invalid address format", async () => {
+    it("returns 403 when body address is not a valid Stellar format", async () => {
+      // bindAuthenticatedWallet runs before validate, so an invalid-format
+      // address (which cannot match the Stellar-format JWT wallet) is rejected
+      // with 403 earlier than Zod's 400. The 403-mismatch happy-path test
+      // above already covers the user-imperonation intent (OTHER_ADDRESS).
       const res = await request(app)
         .post("/api/rounds/round-1/bet")
+        .set("Authorization", `Bearer ${token}`)
         .send({ address: "INVALID", amount: 10, side: "UP" });
 
-      expect(res.status).toBe(400);
-      expect(res.body.error).toBe("ValidationError");
-      expect(res.body.code).toBe("VALIDATION_ERROR");
+      expect(res.status).toBe(403);
+      expect(res.body.error).toMatch(/match authenticated user/i);
     });
   });
 });

--- a/src/tests/hackathon-endpoints.spec.ts
+++ b/src/tests/hackathon-endpoints.spec.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeAll } from '@jest/globals';
 import request from 'supertest';
+import { UserRole } from '@prisma/client';
+import { generateToken } from '../utils/jwt.util';
 
 // Mock Stellar and Soroban services to prevent loading @stellar/stellar-sdk (which contains ESM files that Jest fails to parse)
 jest.mock('../services/stellar.service', () => ({
@@ -23,6 +25,7 @@ describe('Hackathon Endpoints & Middleware', () => {
   const app = createApp();
 
   const validAddress = 'GBZXF5Z5S5JQLYQR3P6F4N6M4E2O3K2N4M4H4K4K4K4K4K4K4K4K4K4K'; // Valid Stellar format
+  const token = generateToken('hackathon-integration-user', validAddress, UserRole.USER);
 
   beforeAll(async () => {
     // Ensure database is seeded for tests
@@ -98,7 +101,16 @@ describe('Hackathon Endpoints & Middleware', () => {
     });
   });
 
-  describe('POST /api/rounds/hackathon/up-down/:id/bet', () => {
+  describe('POST /api/rounds/hackathon/up-down/:id/bet (auth required)', () => {
+    it('returns 401 without an auth token', async () => {
+      const res = await request(app)
+        .post('/api/rounds/hackathon/up-down/btc-updown-live/bet')
+        .send({ address: validAddress, amount: 200, side: 'UP' });
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe('No token provided');
+    });
+
     it('persists the bet, updates user balance, and updates the round pool', async () => {
       // Get round initial pools
       const roundBefore = (await db.select().from(hackathonRounds).where(eq(hackathonRounds.id, 'btc-updown-live')))[0];
@@ -107,6 +119,7 @@ describe('Hackathon Endpoints & Middleware', () => {
       // Place bet
       const res = await request(app)
         .post('/api/rounds/hackathon/up-down/btc-updown-live/bet')
+        .set('Authorization', `Bearer ${token}`)
         .send({
           address: validAddress,
           amount: 200,
@@ -125,7 +138,16 @@ describe('Hackathon Endpoints & Middleware', () => {
     });
   });
 
-  describe('POST /api/rounds/hackathon/precision/:id/bet', () => {
+  describe('POST /api/rounds/hackathon/precision/:id/bet (auth required)', () => {
+    it('returns 401 without an auth token', async () => {
+      const res = await request(app)
+        .post('/api/rounds/hackathon/precision/eth-precision-live/bet')
+        .send({ address: validAddress, amount: 150, predictedPrice: 3250 });
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe('No token provided');
+    });
+
     it('persists the bet and updates round totalPool and predictionCount', async () => {
       // Get round initial pools
       const roundBefore = (await db.select().from(hackathonRounds).where(eq(hackathonRounds.id, 'eth-precision-live')))[0];
@@ -135,6 +157,7 @@ describe('Hackathon Endpoints & Middleware', () => {
       // Place bet
       const res = await request(app)
         .post('/api/rounds/hackathon/precision/eth-precision-live/bet')
+        .set('Authorization', `Bearer ${token}`)
         .send({
           address: validAddress,
           amount: 150,

--- a/src/tests/hackathon.http.spec.ts
+++ b/src/tests/hackathon.http.spec.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, jest } from '@jest/globals';
 import request from 'supertest';
+import { UserRole } from '@prisma/client';
+import { generateToken } from '../utils/jwt.util';
 
 // Mock Stellar and Soroban services to prevent loading @stellar/stellar-sdk (which contains ESM files that Jest fails to parse)
 jest.mock('../services/stellar.service', () => ({
@@ -17,6 +19,11 @@ jest.mock('../services/soroban.service', () => ({
 import app from '../app';
 
 describe('Hackathon HTTP Endpoints (Integration)', () => {
+  // Valid Stellar-format (G + 55 chars) used as authenticated betting wallet
+  // for the hackathon bet smoke tests below.
+  const hackerWallet = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+  const hackerToken = generateToken('hackathon-http-user', hackerWallet, UserRole.USER);
+
   afterAll(async () => {
     const { pool } = require('../db/db');
     await pool.end();
@@ -168,56 +175,65 @@ describe('Hackathon HTTP Endpoints (Integration)', () => {
     });
   });
 
-  describe('POST /api/rounds/hackathon/up-down/:id/bet', () => {
+  describe('POST /api/rounds/hackathon/up-down/:id/bet (auth required)', () => {
+    it('returns 401 when no Authorization header is provided', async () => {
+      const res = await request(app)
+        .post('/api/rounds/hackathon/up-down/btc-updown-live/bet')
+        .send({ address: hackerWallet, amount: 100, side: 'UP' });
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe('No token provided');
+    });
+
     it('records an up-down bet and matches success schema', async () => {
       const payload = {
-        address: 'GCQ2...MOCK', // Mock format for tests
+        address: hackerWallet,
         amount: 100,
         side: 'UP',
       };
-      // Note: validation might fail if address is not a strict Stellar address
-      // but if the test runs against a mock backend that skips it, it will pass.
       const res = await request(app)
-        .post('/api/rounds/hackathon/up-down/mock-round-id/bet')
+        .post('/api/rounds/hackathon/up-down/btc-updown-live/bet')
+        .set('Authorization', `Bearer ${hackerToken}`)
         .send(payload);
 
-      // If validation fails (e.g., 400 Bad Request due to address validation),
-      // we only assert the 400 shape. Ideally, we provide valid data.
-      if (res.status === 200) {
-        expect(res.body).toEqual(
-          expect.objectContaining({
-            success: true,
-            message: expect.any(String),
-          })
-        );
-      } else {
-        expect(res.status).toBe(400); // Validation error
-        expect(res.body).toHaveProperty('error');
-      }
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(
+        expect.objectContaining({
+          success: true,
+          message: expect.any(String),
+        })
+      );
     });
   });
 
-  describe('POST /api/rounds/hackathon/precision/:id/bet', () => {
+  describe('POST /api/rounds/hackathon/precision/:id/bet (auth required)', () => {
+    it('returns 401 when no Authorization header is provided', async () => {
+      const res = await request(app)
+        .post('/api/rounds/hackathon/precision/eth-precision-live/bet')
+        .send({ address: hackerWallet, amount: 50, predictedPrice: 65000.5 });
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe('No token provided');
+    });
+
     it('records a precision bet and matches success schema', async () => {
       const payload = {
-        address: 'GCQ2...MOCK',
+        address: hackerWallet,
         amount: 50,
         predictedPrice: 65000.5,
       };
       const res = await request(app)
-        .post('/api/rounds/hackathon/precision/mock-round-id/bet')
+        .post('/api/rounds/hackathon/precision/eth-precision-live/bet')
+        .set('Authorization', `Bearer ${hackerToken}`)
         .send(payload);
 
-      if (res.status === 200) {
-        expect(res.body).toEqual(
-          expect.objectContaining({
-            success: true,
-            message: expect.any(String),
-          })
-        );
-      } else {
-        expect(res.status).toBe(400);
-      }
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(
+        expect.objectContaining({
+          success: true,
+          message: expect.any(String),
+        })
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #399

This PR protects the hackathon demo bet POST endpoints behind the same Stellar JWT auth chain that already guards `/api/bets/*`. The endpoints were previously unauthenticated open relays — anyone could `POST` a bet on behalf of any address.

**Endpoints now guarded:**
- `POST /api/rounds/:id/bet`
- `POST /api/rounds/hackathon/up-down/:id/bet`
- `POST /api/rounds/hackathon/precision/:id/bet`

**Middleware chain on each endpoint:**
1. `verifyStellarAuth` — reject missing/invalid Bearer token (401)
2. `bindAuthenticatedWallet` — reject body addresses that do not match the authenticated JWT wallet (403), then normalize `req.body.address` to the JWT wallet
3. `validate(schema)` — Zod validation on the now-auth-bound body

`bindAuthenticatedWallet` runs **before** `validate` so impersonation is rejected before any field-level schema check.

## What changed

- `src/routes/rounds.ts` — applied `verifyStellarAuth` + `bindAuthenticatedWallet` to all three bet POST endpoints via a shared `hackathonBetAuth` array. Reorganized handlers for readability; no behavioral change to the GET `/` route or any other endpoint.
- `src/tests/hackathon-bets.routes.spec.ts` — rewritten test suite. Adds JWT setup via `generateToken`, sends auth headers on happy-path tests, and adds explicit 401 (missing / malformed / invalid Bearer) and 403 (mismatched body address) coverage for all three endpoints.
- `src/tests/hackathon-endpoints.spec.ts` — added JWT setup and 401 negative-case tests; existing POST tests now include the `Authorization` header.
- `src/tests/hackathon.http.spec.ts` — added JWT setup, switched the address in the integration smoke tests to a valid Stellar-format wallet, and replaced the previously tautological `if status === 200` / `else expect 200` branches with direct assertions. Added 401 tests.

## Acceptance criteria

- [x] **Unauthenticated bets return 401.** New tests `returns 401 when no Authorization header is provided` (per endpoint) verify the message and status.
- [x] **Mismatched address rejected.** New tests `returns 403 when body address does not match the authenticated wallet` (per endpoint) verify the message and status; also `returns 403 when body address is not a valid Stellar format` covers the case where the address is structurally invalid (bind rejects before Zod).
- [x] **Happy path still works.** `returns 200 for valid … bet payload with matching JWT wallet` (per endpoint, with matching and omitted body variants) verify the authenticated happy path; integration tests in `hackathon-endpoints.spec.ts` continue to assert pool updates post-bet.
- [x] **Demo bet APIs are not open relays.** The three endpoints now require a Stellar JWT and bind the wallet before reaching the service layer.

## Test coverage

- **Unit** (`src/tests/hackathon-bets.routes.spec.ts`) — fully mocked. Covers all 401/403/400/200 paths for all three endpoints. No DB required.
- **Integration** (`src/tests/hackathon-endpoints.spec.ts`, `src/tests/hackathon.http.spec.ts`) — added 401 negative-case tests and updated happy paths to use real Stellar-format wallets + JWT.

## Note on pre-existing tsc errors (NOT introduced by this PR)

`npx tsc --noEmit` surfaces pre-existing errors on `TevaLabs/Xelma-Backend@main`. I confirmed by running the same command on `main` (before this branch) and on `fix/399-hackathon-bet-auth` — identical output:

```
src/routes/bets.routes.ts(117,1): error TS1109: Expression expected.
src/routes/bets.routes.ts(220,1): error TS1109: Expression expected.
src/services/websocket.service.ts(38,1): error TS1131: Property or signature expected.
EXIT=2
```

These are unrelated to this PR — they live in `bets.routes.ts` (untouched) and `websocket.service.ts` (untouched), and predate this change. Please do not misread the CI lint failure as a regression caused by this PR. Happy to file a follow-up issue/PR to address them separately.

## Security note

Bind-the-wallet runs before validate. Without this ordering, a malicious client can send a body that Zod won't reject (e.g. empty address or a structurally-invalid Stellar string) and either bypass validation or leak information through validation error detail. The chosen ordering also forces `req.body.address` to be the authenticated wallet, so downstream handlers (and the DB write through `getRepositories().rounds.placeBet`) cannot be tricked by client-supplied addresses.

## Files changed

```
 src/routes/rounds.ts                    |  71 ++++++++----
 src/tests/hackathon-bets.routes.spec.ts | 195 +++++++++++++++++++++++++++-----
 src/tests/hackathon-endpoints.spec.ts   |  27 ++++-
 src/tests/hackathon.http.spec.ts        |  78 ++++++++-----
 4 files changed, 290 insertions(+), 81 deletions(-)
```
