### PR TITLE
docs: fix CLAUDE.md stale testing and decimal util docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ```bash
 # Development
-npm run dev              # Start dev server with nodemon (auto-reload)
+npm run dev              # Start dev server with ts-node-dev (auto-reload)
 npm run build            # Compile TypeScript to dist/
 npm start                # Start production server (node dist/index.js)
 
@@ -15,6 +15,9 @@ npm run lint             # tsc --noEmit (type-check only, no output)
 
 # Testing
 npm test                 # Run all tests
+npm run test:unit        # Run unit tests only
+npm run test:unit:coverage # Unit tests with coverage report
+npm run test:integration # Run integration tests only
 npm run test:watch       # Run tests in watch mode
 
 # Run a single test file
@@ -51,11 +54,15 @@ npm run ci
 - **Soroban** — Smart contract interactions via `@tevalabs/xelma-bindings` and `@stellar/stellar-sdk`; controlled by `SOROBAN_ADMIN_SECRET` / `SOROBAN_ORACLE_SECRET`
 - **WebSocket** — Real-time events (round open/close/resolve, price ticks, notifications) broadcast via Socket.IO in [src/services/websocket.service.ts](src/services/websocket.service.ts)
 
-**Monetary precision:** All balance/amount fields use `Decimal(20, 8)` in Prisma. Never use native JS floats for financial math — use the utilities in [src/utils/decimal.ts](src/utils/decimal.ts).
+**Monetary precision:** All balance/amount fields use `Decimal(20, 8)` in Prisma. Never use native JS floats for financial math — use the utilities in [src/utils/decimal.util.ts](src/utils/decimal.util.ts).
 
 ## Testing
 
-Tests live in `src/tests/*.spec.ts`. Several tests are **excluded from the default test run** in [jest.config.ts](jest.config.ts) (`testPathIgnorePatterns`): `rounds.routes.spec.ts`, `predictions.routes.spec.ts`, `round.spec.ts`, `concurrent-rounds.spec.ts`, `education-tip.route.spec.ts`.
+Tests live in `src/tests/*.spec.ts`. Tests are split into **unit** and **integration** projects in [jest.config.ts](jest.config.ts):
+- **Unit tests** (`npm run test:unit`) — fast, no external dependencies
+- **Integration tests** (`npm run test:integration`) — require PostgreSQL
+
+The `integrationTestFiles` array in `jest.config.ts` defines which tests run as integration. Both projects run under `npm test`.
 
 Tests require a running PostgreSQL database. The test environment is configured in [.env.test](.env.test) and loaded by [jest.setup.js](jest.setup.js). The CI pipeline uses a PostgreSQL 16 service container.
 


### PR DESCRIPTION
## Summary

Update `CLAUDE.md` to match the current repo state: correct the decimal util file path, remove the stale `testPathIgnorePatterns` claim, align script descriptions with `package.json`, and add missing test commands.

## What changed

- **Decimal path**: `src/utils/decimal.ts` → `src/utils/decimal.util.ts` (line 57)
- **Dev command**: Changed "nodemon" → "ts-node-dev" to match `package.json` (line 9)
- **Testing section** (lines 59–67): Replaced stale paragraph claiming tests were "excluded from default test run via `testPathIgnorePatterns`" with an accurate description of the jest project split (unit/integration) and how `integrationTestFiles` works
- **Added commands**: `test:unit`, `test:unit:coverage`, `test:integration` to the Commands block (lines 18–20)

## Key design decisions

- Removed the stale list of 5 test files (`rounds.routes.spec.ts`, `predictions.routes.spec.ts`, etc.) that were claimed to be excluded — in reality all tests run under `npm test` via two projects, nothing is excluded from the default run
- Described the project-based split mechanism instead of the incorrect `testPathIgnorePatterns` mechanism

## Acceptance criteria checklist

- [x] Decimal path correct (`src/utils/decimal.util.ts`)
- [x] Test commands accurate (matched to `package.json` scripts)
- [x] No stale ignore list (removed the incomplete `testPathIgnorePatterns` list)

## Verification

This is a documentation-only change to `CLAUDE.md`. No TypeScript/JS code was modified, so `npm run lint` (tsc --noEmit) is not affected.

```
$ git diff --stat
 CLAUDE.md | 13 +++++++++----
 1 file changed, 10 insertions(+), 3 deletions(-)
```

## Follow-ups

None.

## Security note

No secrets, tokens, or environment variables touched. Documentation only.

Closes #414