### PR TITLE
feat(#406): add authenticated Soroban claim/payout endpoint

### DIFF
--- a/src/routes/bets.routes.ts
+++ b/src/routes/bets.routes.ts
@@ -1,7 +1,11 @@
 import { Router, Response, NextFunction } from "express";
 import { validate } from "../middleware/validate.middleware";
-import { verifyStellarAuth, AuthenticatedRequest } from "../middleware/auth.middleware";
-import { upDownBetSchema, precisionBetSchema } from "../schemas/bets.schema";
+import {
+  verifyStellarAuth,
+  bindAuthenticatedWallet,
+  AuthenticatedRequest,
+} from "../middleware/auth.middleware";
+import { upDownBetSchema, precisionBetSchema, claimWinningsSchema } from "../schemas/bets.schema";
 import betService from "../services/bet.service";
 import {
   acquireIdempotencyLock,
@@ -213,6 +217,131 @@ router.post(
 
       if (error?.message?.includes("Circuit breaker")) {
         return next(new ExternalServiceError("Contract interaction failed. Please try again.", ErrorCode.EXTERNAL_SERVICE_ERROR));
+      }
+      next(error);
+    }
+  }) as any,
+);
+
+/**
+ * @swagger
+ * /api/bets/claim:
+ *   post:
+ *     summary: Claim pending Soroban winnings
+ *     tags: [bets]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: header
+ *         name: Idempotency-Key
+ *         schema: { type: string }
+ *         required: false
+ *     requestBody:
+ *       required: false
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               address: { type: string, description: "Optional; must match JWT wallet when provided" }
+ *     responses:
+ *       200:
+ *         description: Claim recorded or submitted on-chain
+ *       401:
+ *         description: Missing or invalid JWT
+ *       403:
+ *         description: Wallet address mismatch
+ *       409:
+ *         description: Idempotency key conflict
+ *       422:
+ *         description: No claimable winnings / invalid contract state
+ *       503:
+ *         description: Contract interaction failed
+ */
+router.post(
+  "/claim",
+  verifyStellarAuth,
+  (req, _res, next) => {
+    req.body = req.body ?? {};
+    next();
+  },
+  bindAuthenticatedWallet,
+  validate(claimWinningsSchema),
+  (async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    const idempotencyKey = req.headers["idempotency-key"] as string | undefined;
+    const userId = req.user!.userId;
+    const endpoint = "/api/bets/claim";
+    let lockAcquired = false;
+
+    try {
+      if (idempotencyKey) {
+        if (!isValidIdempotencyKey(idempotencyKey)) {
+          throw new ValidationError(
+            "Invalid Idempotency-Key format. Must be 8-255 alphanumeric characters."
+          );
+        }
+
+        const lockResult = await acquireIdempotencyLock(
+          userId,
+          endpoint,
+          idempotencyKey,
+          req.body,
+          24
+        );
+
+        if (lockResult.isIdempotent && lockResult.cachedResponse) {
+          return res
+            .status(lockResult.cachedResponse.status)
+            .json(lockResult.cachedResponse.body);
+        }
+
+        if (lockResult.error) {
+          throw new ConflictError(
+            lockResult.error,
+            ErrorCode.IDEMPOTENCY_KEY_CONFLICT
+          );
+        }
+
+        lockAcquired = !!lockResult.lockAcquired;
+      }
+
+      const result = await betService.claimWinnings(req.body.address, idempotencyKey);
+      const responseBody = {
+        success: true,
+        message:
+          result.state === "stub"
+            ? "Claim recorded (stub)"
+            : "Winnings claimed on-chain",
+        state: result.state,
+        amount: result.amount,
+        ...(result.txHash ? { txHash: result.txHash } : {}),
+      };
+
+      if (idempotencyKey && lockAcquired) {
+        await storeIdempotencyResult(
+          userId,
+          endpoint,
+          idempotencyKey,
+          req.body,
+          200,
+          responseBody,
+          { ttlHours: 24 }
+        );
+      }
+
+      res.json(responseBody);
+    } catch (error: any) {
+      if (idempotencyKey && lockAcquired) {
+        await releaseIdempotencyLock(userId, endpoint, idempotencyKey);
+      }
+
+      if (error?.message?.includes("Circuit breaker")) {
+        return next(
+          new ExternalServiceError(
+            "Contract interaction failed. Please try again.",
+            ErrorCode.EXTERNAL_SERVICE_ERROR
+          )
+        );
       }
       next(error);
     }

--- a/src/schemas/bets.schema.ts
+++ b/src/schemas/bets.schema.ts
@@ -17,4 +17,9 @@ export const precisionBetSchema = z.object({
     .positive("predictedPrice must be a positive number"),
 });
 
+/** Claim body: address is bound from JWT via bindAuthenticatedWallet before validate. */
+export const claimWinningsSchema = z.object({
+  address: stellarAddressSchema,
+});
+
 export const betSchema = z.union([upDownBetSchema, precisionBetSchema]);

--- a/src/security/route-auth.registry.ts
+++ b/src/security/route-auth.registry.ts
@@ -51,6 +51,7 @@ export const ROUTE_AUTH_REGISTRY: RouteAuthEntry[] = [
   // Bets (JWT required — wallet bound from token)
   { method: "POST", path: "/api/bets/up-down", auth: RouteAuthLevel.AUTHENTICATED },
   { method: "POST", path: "/api/bets/precision", auth: RouteAuthLevel.AUTHENTICATED },
+  { method: "POST", path: "/api/bets/claim", auth: RouteAuthLevel.AUTHENTICATED },
 
   // Predictions
   { method: "POST", path: "/api/predictions/submit", auth: RouteAuthLevel.AUTHENTICATED },

--- a/src/security/route-parity.registry.ts
+++ b/src/security/route-parity.registry.ts
@@ -38,6 +38,7 @@ export const PARITY_ALLOWLIST: ParityAllowlistEntry[] = [
   { method: "POST", path: "/api/rounds/:id/simulate", only: "main", reason: "Round simulation is production-only." },
   { method: "POST", path: "/api/bets/up-down", only: "main", reason: "Authenticated bet placement is production-only." },
   { method: "POST", path: "/api/bets/precision", only: "main", reason: "Authenticated bet placement is production-only." },
+  { method: "POST", path: "/api/bets/claim", only: "main", reason: "Authenticated claim/payout is production-only." },
   { method: "POST", path: "/api/predictions/submit", only: "main", reason: "Prediction submission is production-only." },
   { method: "POST", path: "/api/predictions/batch-submit", only: "main", reason: "Prediction submission is production-only." },
   { method: "GET", path: "/api/predictions/user", only: "main", reason: "Prediction history is production-only." },

--- a/src/services/bet-audit.service.ts
+++ b/src/services/bet-audit.service.ts
@@ -36,12 +36,12 @@ import { prisma } from "../lib/prisma";
 import { GameMode } from "@prisma/client";
 
 export interface BetAuditEvent {
-  event: "BET_ACCEPTED";
+  event: "BET_ACCEPTED" | "CLAIM_ACCEPTED";
   roundId?: string;
   address: string;
   amount: number;
   side?: "UP" | "DOWN";
-  mode: "UP_DOWN" | "PRECISION";
+  mode?: "UP_DOWN" | "PRECISION";
   result: string;
   txHash?: string;
   createdAt: string;
@@ -52,6 +52,13 @@ export interface BetAuditParams {
   amount: number;
   side?: "UP" | "DOWN";
   mode: "UP_DOWN" | "PRECISION";
+  result: string;
+  txHash?: string;
+}
+
+export interface ClaimAuditParams {
+  address: string;
+  amount: number;
   result: string;
   txHash?: string;
 }
@@ -109,6 +116,36 @@ class BetAuditService {
   }
 
   /**
+   * Emit a CLAIM_ACCEPTED audit event for a successful claim/payout.
+   * Same storage modes as BET_ACCEPTED; never emitted for failed claims.
+   */
+  emitClaimAccepted(params: ClaimAuditParams): BetAuditEvent {
+    const event: BetAuditEvent = {
+      event: "CLAIM_ACCEPTED",
+      address: params.address,
+      amount: params.amount,
+      result: params.result,
+      txHash: params.txHash,
+      createdAt: new Date().toISOString(),
+    };
+
+    this.events.push(event);
+
+    logger.info("Claim accepted", { audit: true, ...event });
+
+    if (this.storageMode === "database") {
+      void this.persistClaimToDatabase(event).catch((error) => {
+        logger.error("Failed to persist claim audit event to database", {
+          error: error instanceof Error ? error.message : "Unknown error",
+          eventType: event.event,
+        });
+      });
+    }
+
+    return event;
+  }
+
+  /**
    * Asynchronously enrich the event with the active round ID and persist
    * to the database when database mode is enabled.
    *
@@ -161,6 +198,26 @@ class BetAuditService {
           amount: event.amount,
           side: event.side,
           mode: event.mode,
+          result: event.result,
+          txHash: event.txHash,
+        } as any,
+        timestamp: new Date(event.createdAt),
+      },
+    });
+  }
+
+  private async persistClaimToDatabase(event: BetAuditEvent): Promise<void> {
+    await prisma.auditLog.create({
+      data: {
+        eventType: event.event,
+        severity: "info",
+        message: `Claim accepted: ${event.amount} XLM`,
+        outcome: "success",
+        actorType: "user",
+        walletAddress: event.address,
+        resourceType: "claim",
+        metadata: {
+          amount: event.amount,
           result: event.result,
           txHash: event.txHash,
         } as any,

--- a/src/services/bet.service.ts
+++ b/src/services/bet.service.ts
@@ -105,6 +105,34 @@ export class BetService {
 
     return result;
   }
+
+  /**
+   * Claims pending on-chain winnings for the authenticated wallet.
+   * Stub mode records a no-op claim for local/hackathon flows.
+   */
+  async claimWinnings(
+    address: string,
+    idempotencyKey?: string
+  ): Promise<{ state: string; amount: number; txHash?: string }> {
+    let result: { state: string; amount: number; txHash?: string };
+
+    if (process.env.BET_STUB_MODE === "true") {
+      logger.info("Claim winnings stub recorded", { address, idempotencyKey });
+      result = { state: "stub", amount: 0 };
+    } else {
+      logger.info("Claiming winnings on-chain", { address, idempotencyKey });
+      result = await sorobanService.claimWinnings(address);
+    }
+
+    betAuditService.emitClaimAccepted({
+      address,
+      amount: result.amount,
+      result: result.state,
+      txHash: result.txHash,
+    });
+
+    return result;
+  }
 }
 
 export default new BetService();

--- a/src/services/soroban.service.ts
+++ b/src/services/soroban.service.ts
@@ -2,10 +2,15 @@ import { Keypair, Networks, Transaction } from "@stellar/stellar-sdk";
 import type { Client as XelmaClient, BetSide, OraclePayload, RoundMode, UserStats } from "@tevalabs/xelma-bindings";
 import logger from "../utils/logger";
 import { toDecimal } from "../utils/decimal.util";
+import { stroopsToXlm } from "../utils/payout.util";
 import { withTimeout, TimeoutResult } from "../utils/timeout-wrapper";
 import { CircuitBreaker, CircuitBreakerOpenError } from "../utils/circuit-breaker";
 import { Decimal } from "@prisma/client/runtime/library";
 import { mapSorobanError } from "../utils/errors";
+import {
+  sorobanRpcCallsTotal,
+  sorobanRpcDurationSeconds,
+} from "../metrics/application.metrics";
 
 export interface SorobanHealth {
   initialized: boolean;
@@ -594,6 +599,60 @@ export class SorobanService {
       });
       return BigInt(0);
     }
+
+    return result.data!;
+  }
+
+  /**
+   * Claims pending winnings on the Soroban contract and credits the user's balance.
+   * Returns the claimed amount in XLM (converted from stroops) plus optional tx hash.
+   *
+   * Uses timeout wrapper with retry logic. Signed by the admin keypair (backend relay).
+   */
+  async claimWinnings(
+    userAddress: string,
+  ): Promise<{ state: string; amount: number; txHash?: string }> {
+    await this.ensureInitialized();
+
+    const result = await this.callWithBreaker("sorobanClaimWinnings", () =>
+      withTimeout(
+        async () => {
+          logger.debug(`Initiating Soroban claimWinnings: user=${userAddress}`);
+
+          const tx = await this.client!.claim_winnings({ user: userAddress });
+          const res = await tx.signAndSend({
+            signTransaction: this.signWithAdmin.bind(this),
+          });
+
+          const claimedStroops = (res as any)?.result ?? tx.result ?? BigInt(0);
+          return {
+            state: "on-chain-success",
+            amount: stroopsToXlm(claimedStroops),
+            txHash: (res as any).hash,
+          };
+        },
+        {
+          timeoutMs: this.CALL_TIMEOUT_MS,
+          operationName: "sorobanClaimWinnings",
+          retries: this.MAX_RETRIES,
+        },
+      ),
+    );
+
+    if (!result.success) {
+      logger.error("Failed to claim winnings on Soroban after retries", {
+        error: result.error?.message,
+        timedOut: result.timedOut,
+        durationMs: result.durationMs,
+      });
+      throw mapSorobanError(result.error?.message);
+    }
+
+    logger.info("Winnings claimed successfully on Soroban", {
+      amount: result.data?.amount,
+      durationMs: result.durationMs,
+      retriesUsed: result.retriesUsed,
+    });
 
     return result.data!;
   }

--- a/src/tests/claim.service.spec.ts
+++ b/src/tests/claim.service.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from "@jest/globals";
+import betService from "../services/bet.service";
+
+jest.mock("../services/soroban.service", () => ({
+  __esModule: true,
+  default: {
+    placeBet: jest.fn(),
+    placePrecisionBet: jest.fn(),
+    claimWinnings: jest.fn(),
+  },
+}));
+
+jest.mock("../utils/logger", () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+jest.mock("../services/bet-audit.service", () => ({
+  __esModule: true,
+  default: {
+    emitBetAccepted: jest.fn(),
+    emitClaimAccepted: jest.fn(),
+  },
+}));
+
+jest.mock("../services/websocket.service", () => ({
+  __esModule: true,
+  default: {
+    emitBetAccepted: jest.fn(),
+  },
+}));
+
+import sorobanService from "../services/soroban.service";
+import betAuditService from "../services/bet-audit.service";
+
+const VALID_ADDRESS = "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890";
+
+describe("BetService.claimWinnings", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns stub claim when BET_STUB_MODE=true", async () => {
+    process.env.BET_STUB_MODE = "true";
+
+    const result = await betService.claimWinnings(VALID_ADDRESS);
+
+    expect(result).toEqual({ state: "stub", amount: 0 });
+    expect(sorobanService.claimWinnings).not.toHaveBeenCalled();
+    expect(betAuditService.emitClaimAccepted).toHaveBeenCalledWith({
+      address: VALID_ADDRESS,
+      amount: 0,
+      result: "stub",
+      txHash: undefined,
+    });
+  });
+
+  it("calls SorobanService and audits when BET_STUB_MODE=false", async () => {
+    process.env.BET_STUB_MODE = "false";
+    (sorobanService.claimWinnings as jest.Mock).mockResolvedValue({
+      state: "on-chain-success",
+      amount: 12.5,
+      txHash: "0xclaim",
+    });
+
+    const result = await betService.claimWinnings(VALID_ADDRESS, "idem-key-1");
+
+    expect(result).toEqual({
+      state: "on-chain-success",
+      amount: 12.5,
+      txHash: "0xclaim",
+    });
+    expect(sorobanService.claimWinnings).toHaveBeenCalledWith(VALID_ADDRESS);
+    expect(betAuditService.emitClaimAccepted).toHaveBeenCalledWith({
+      address: VALID_ADDRESS,
+      amount: 12.5,
+      result: "on-chain-success",
+      txHash: "0xclaim",
+    });
+  });
+
+  it("does not audit when Soroban claim throws", async () => {
+    process.env.BET_STUB_MODE = "false";
+    (sorobanService.claimWinnings as jest.Mock).mockRejectedValue(
+      new Error("contract failed")
+    );
+
+    await expect(betService.claimWinnings(VALID_ADDRESS)).rejects.toThrow(
+      "contract failed"
+    );
+    expect(betAuditService.emitClaimAccepted).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/payout.util.spec.ts
+++ b/src/tests/payout.util.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  STROOPS_PER_XLM,
+  stroopsToXlm,
+  xlmToStroops,
+  calculatePayout,
+} from "../utils/payout.util";
+import { toDecimal } from "../utils/decimal.util";
+
+describe("payout.util", () => {
+  it("converts stroops to XLM", () => {
+    expect(STROOPS_PER_XLM).toBe(10_000_000);
+    expect(stroopsToXlm(BigInt(50_000_000))).toBe(5);
+    expect(stroopsToXlm(0)).toBe(0);
+  });
+
+  it("converts XLM to stroops", () => {
+    expect(xlmToStroops(5)).toBe(BigInt(50_000_000));
+    expect(xlmToStroops("1.5")).toBe(BigInt(15_000_000));
+  });
+
+  it("round-trips XLM through stroops", () => {
+    expect(stroopsToXlm(xlmToStroops(7.25))).toBe(7.25);
+  });
+
+  it("calculatePayout still shares losing pool correctly", () => {
+    const payout = calculatePayout(
+      toDecimal(10),
+      toDecimal(50),
+      toDecimal(100)
+    );
+    expect(payout.toNumber()).toBe(30);
+  });
+});

--- a/src/tests/soroban-error-mapper.spec.ts
+++ b/src/tests/soroban-error-mapper.spec.ts
@@ -14,6 +14,13 @@ describe("mapSorobanError", () => {
     expect(error.message).toBe("Insufficient funds for contract operation.");
   });
 
+  it("maps 'nothing to claim' to CONTRACT_INVALID_STATE", () => {
+    const error = mapSorobanError("HostError: nothing to claim");
+    expect(error).toBeInstanceOf(BusinessRuleError);
+    expect(error.code).toBe(ErrorCode.CONTRACT_INVALID_STATE);
+    expect(error.message).toBe("No claimable winnings available.");
+  });
+
   it("maps 'invalid state' to CONTRACT_INVALID_STATE BusinessRuleError", () => {
     const error = mapSorobanError("Error 14: invalid state in contract");
     expect(error).toBeInstanceOf(BusinessRuleError);

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -308,6 +308,17 @@ export function mapSorobanError(errorMsg: string | undefined): AppError {
     );
   }
 
+  if (
+    msg.includes("no pending") ||
+    msg.includes("nothing to claim") ||
+    msg.includes("already claimed")
+  ) {
+    return new BusinessRuleError(
+      "No claimable winnings available.",
+      ErrorCode.CONTRACT_INVALID_STATE
+    );
+  }
+
   if (msg.includes("invalid state")) {
     return new BusinessRuleError(
       "Contract operation rejected due to invalid state.",

--- a/src/utils/payout.util.ts
+++ b/src/utils/payout.util.ts
@@ -1,5 +1,8 @@
 import { Decimal } from '@prisma/client/runtime/library';
-import { decAdd, decDiv, decMul } from './decimal.util';
+import { decAdd, decDiv, decMul, toDecimal } from './decimal.util';
+
+/** 1 XLM = 10^7 stroops (Soroban / Stellar native unit). */
+export const STROOPS_PER_XLM = 10_000_000;
 
 /**
  * Calculates the payout for a correct prediction: stake + (stake / winningPool) * losingPool
@@ -15,4 +18,14 @@ export function calculatePayout(
   // stake + (stake / winningPool) * losingPool
   const shareOfLosingPool = decMul(decDiv(stake, winningPool), losingPool);
   return decAdd(stake, shareOfLosingPool);
+}
+
+/** Converts stroops (contract i128) to XLM as a JS number. */
+export function stroopsToXlm(stroops: bigint | number | string): number {
+  return Number(stroops) / STROOPS_PER_XLM;
+}
+
+/** Converts an XLM amount to stroops for contract calls. */
+export function xlmToStroops(amount: number | string | Decimal): bigint {
+  return BigInt(toDecimal(amount).mul(STROOPS_PER_XLM).toFixed(0));
 }


### PR DESCRIPTION
Implements the claim payout workflow by adding a new authenticated API endpoint that submits winning claims to the Soroban contract, records audit events, and provides user-friendly error handling.

What was implemented
Added POST /api/bets/claim with:
JWT authentication
Wallet ownership verification
Optional Idempotency-Key support for safe retries
Implemented SorobanService.claimWinnings() to invoke the Soroban contract's claim_winnings entrypoint using the configured admin signer.
Integrated audit logging by recording successful claims as CLAIM_ACCEPTED through the bet audit service.
Added error mapping to return clean 422 Unprocessable Entity responses for contract errors such as:
Nothing to claim
No pending payouts
Added reusable stroops utility helpers in payout.util.ts.
Testing

Added and updated focused tests covering:

claim.service.spec.ts
payout.util.spec.ts
Extended soroban-error-mapper.spec.ts

Result: 13 tests passed

Notes
Heavy route integration and database suites were intentionally skipped during local validation; these will be exercised by the project's CI pipeline.
The endpoint supports idempotent payout requests through the optional Idempotency-Key header.
Example Request
POST /api/bets/claim
Authorization: Bearer <jwt>
Idempotency-Key: claim-abc-12345

 Closes #406